### PR TITLE
Checking permissions sequentially made possible

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -128,14 +128,14 @@ final class DexterInstance {
 
   private void finishWithGrantedPermission(String permission) {
     activity.finish();
-    listener.onPermissionGranted(permission);
     isRequestingPermission.set(false);
+    listener.onPermissionGranted(permission);
   }
 
   private void finishWithDeniedPermission(String permission) {
     activity.finish();
-    listener.onPermissionDenied(permission);
     isRequestingPermission.set(false);
+    listener.onPermissionDenied(permission);
   }
 
   private int getPermissionCodeForPermission(String permission) {


### PR DESCRIPTION
The current order of methods being called in `DexterInstance's` methods `finishWithGrantedPermission` and `finishWithDeniedPermission` does not let you call `checkPermission` right from the `PermissionListener` callbacks. Changing it will let us call `checkPermission` sequentially (right from the listener).