### PR TITLE
activity-memory-leak-fix: DexterInstance calls context.getApplication…

### DIFF
--- a/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
+++ b/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
@@ -35,6 +35,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -53,6 +54,8 @@ import static org.mockito.Mockito.when;
 
   @Before public void setUp() {
     IntentProvider intentProvider = new IntentMockProvider(intent);
+    Context mockApplicationContext = mock(Context.class);
+    when(context.getApplicationContext()).thenReturn(mockApplicationContext);
     dexter = new DexterInstance(context, androidPermissionService, intentProvider);
   }
 


### PR DESCRIPTION
…Context() to avoid leaks if the user initializes Dexter inside an Activity. Also, DexterInstance now holds the  reference in a WeakReference variable. May need to add null checks around weakReferenceActivity.get(). EO