### PR TITLE
Save listener ref only if needed

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -109,10 +109,11 @@ final class DexterInstance {
    * request for permission process.
    */
   void continuePendingRequestsIfPossible(MultiplePermissionsListener listener) {
-    boolean isShowingRationale = !pendingPermissions.isEmpty() && !rationaleAccepted.get();
-    this.listener = listener;
-    if (isShowingRationale) {
-      onActivityReady(activity);
+    if (!pendingPermissions.isEmpty()) {
+      this.listener = listener;
+      if (!rationaleAccepted.get()) {
+        onActivityReady(activity);
+      }
     }
   }
 


### PR DESCRIPTION
Only keep the listener reference in ``continuePendingRequestsIfPossible`` if we still have work to do with permissions. This PR ensures that every assigned listener is being cleaned up when the permission process finishes or it's not held at all if it's not needed.