### PR TITLE
Throw if missed initialize on dexter

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -55,7 +55,7 @@ public final class Dexter {
    * @param permission One of the values found in {@link android.Manifest.permission}
    */
   public static void checkPermission(PermissionListener listener, String permission) {
-    assertInstanceNotNull();
+    checkInstanceNotNull();
     instance.checkPermission(listener, permission);
   }
 
@@ -68,7 +68,7 @@ public final class Dexter {
    * @param permissions Array of values found in {@link android.Manifest.permission}
    */
   public static void checkPermissions(MultiplePermissionsListener listener, String... permissions) {
-    assertInstanceNotNull();
+    checkInstanceNotNull();
     instance.checkPermissions(listener, Arrays.asList(permissions));
   }
 
@@ -81,7 +81,7 @@ public final class Dexter {
    */
   public static void checkPermissions(MultiplePermissionsListener listener,
       Collection<String> permissions) {
-    assertInstanceNotNull();
+    checkInstanceNotNull();
     instance.checkPermissions(listener, permissions);
   }
 
@@ -91,7 +91,7 @@ public final class Dexter {
    * or it will cause an exception.
    */
   public static boolean isRequestOngoing() {
-    assertInstanceNotNull();
+    checkInstanceNotNull();
     return instance.isRequestOngoing();
   }
 
@@ -101,7 +101,7 @@ public final class Dexter {
    * rotated.
    */
   public static void continuePendingRequestsIfPossible(MultiplePermissionsListener listener) {
-    assertInstanceNotNull();
+    checkInstanceNotNull();
     instance.continuePendingRequestsIfPossible(listener);
   }
 
@@ -111,11 +111,11 @@ public final class Dexter {
    * rotated.
    */
   public static void continuePendingRequestIfPossible(PermissionListener listener) {
-    assertInstanceNotNull();
+    checkInstanceNotNull();
     instance.continuePendingRequestIfPossible(listener);
   }
 
-  private static void assertInstanceNotNull() {
+  private static void checkInstanceNotNull() {
     if (instance == null) {
       throw new NullPointerException("context == null \n Must call \"initialize\" on Dexter");
     }

--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -116,8 +116,9 @@ public final class Dexter {
   }
 
   private static void assertInstanceNotNull() {
-    if (instance == null)
+    if (instance == null) {
       throw new NullPointerException("context == null \n Must call \"initialize\" on Dexter");
+    }
   }
 
   /**

--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -55,6 +55,7 @@ public final class Dexter {
    * @param permission One of the values found in {@link android.Manifest.permission}
    */
   public static void checkPermission(PermissionListener listener, String permission) {
+    assertInstanceNotNull();
     instance.checkPermission(listener, permission);
   }
 
@@ -67,6 +68,7 @@ public final class Dexter {
    * @param permissions Array of values found in {@link android.Manifest.permission}
    */
   public static void checkPermissions(MultiplePermissionsListener listener, String... permissions) {
+    assertInstanceNotNull();
     instance.checkPermissions(listener, Arrays.asList(permissions));
   }
 
@@ -79,6 +81,7 @@ public final class Dexter {
    */
   public static void checkPermissions(MultiplePermissionsListener listener,
       Collection<String> permissions) {
+    assertInstanceNotNull();
     instance.checkPermissions(listener, permissions);
   }
 
@@ -88,6 +91,7 @@ public final class Dexter {
    * or it will cause an exception.
    */
   public static boolean isRequestOngoing() {
+    assertInstanceNotNull();
     return instance.isRequestOngoing();
   }
 
@@ -97,6 +101,7 @@ public final class Dexter {
    * rotated.
    */
   public static void continuePendingRequestsIfPossible(MultiplePermissionsListener listener) {
+    assertInstanceNotNull();
     instance.continuePendingRequestsIfPossible(listener);
   }
 
@@ -106,7 +111,13 @@ public final class Dexter {
    * rotated.
    */
   public static void continuePendingRequestIfPossible(PermissionListener listener) {
+    assertInstanceNotNull();
     instance.continuePendingRequestIfPossible(listener);
+  }
+
+  private static void assertInstanceNotNull() {
+    if (instance == null)
+      throw new NullPointerException("context == null \n Must call \"initialize\" on Dexter");
   }
 
   /**


### PR DESCRIPTION
Just ran into a stack trace where I missed `initialize`. I find this change will throw clear on stack trace.

Thanks for the clean library.