### PR TITLE
Checking permissions sequentially re-enabled

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -247,8 +247,9 @@ final class DexterInstance {
       activity.finish();
       isRequestingPermission.set(false);
       rationaleAccepted.set(false);
-      listener.onPermissionsChecked(multiplePermissionsReport);
+      MultiplePermissionsListener currentListener = listener;
       listener = EMPTY_LISTENER;
+      currentListener.onPermissionsChecked(multiplePermissionsReport);
     }
   }
 


### PR DESCRIPTION
Hi guys (once again :smile: )!
The second version of `Dexter` reintroduced the bug that prevents users from calling `checkPermission` or `checkPermissions` directly from `PermissionListener's` callbacks. This time the reason is a bit different though. Currently the `listener` is being overwritten after the `onPermissionsChecked` callback.

This PR fixes the bug.

Best,
Bartosz