### PR TITLE
Remove circular ref when finishing activity

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -245,6 +245,7 @@ final class DexterInstance {
     pendingPermissions.removeAll(permissions);
     if (pendingPermissions.isEmpty()) {
       activity.finish();
+      activity = null;
       isRequestingPermission.set(false);
       rationaleAccepted.set(false);
       MultiplePermissionsListener currentListener = listener;


### PR DESCRIPTION
Fixes issue #34 by breaking the circular ref DexterInstance <-> DexterActivity when finishing the activity