### PR TITLE
Update README.md sample was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,10 @@ If you want to request multiple permissions you just need to do the same but reg
 
 ```java
 Collection<String> permissions = Arrays.asList(
-        	Manifest.permission.CAMERA, Manifest.permission.READ_CONTACTS, Manifest.permission.RECORD_AUDIO);
 Dexter.checkPermissions(new MultiplePermissionsListener() {
-        	@Override public void onPermissionsChecked(MultiplePermissionsReport report) {/* ... */}
-        	@Override public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions, PermissionToken token) {/* ... */}
-        }, permissions);
+    @Override public void onPermissionsChecked(MultiplePermissionsReport report) {/* ... */}
+    @Override public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions, PermissionToken token) {/* ... */}
+}, Manifest.permission.CAMERA, Manifest.permission.READ_CONTACTS, Manifest.permission.RECORD_AUDIO);
 ```
 
 The ``MultiplePermissionsReport`` contains all the details of the permission request like the list of denied/granted permissions or utility methods like ``areAllPermissionsGranted`` and ``isAnyPermissionPermanentlyDenied``.

--- a/README.md
+++ b/README.md
@@ -83,10 +83,11 @@ If you want to request multiple permissions you just need to do the same but reg
 
 ```java
 Collection<String> permissions = Arrays.asList(
+        	Manifest.permission.CAMERA, Manifest.permission.READ_CONTACTS, Manifest.permission.RECORD_AUDIO);
 Dexter.checkPermissions(new MultiplePermissionsListener() {
-	@Override public void onPermissionsChecked(MultiplePermissionsReport report) {/* ... */}
-	@Override public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions, PermissionToken token) {/* ... */}
-}, Manifest.permission.CAMERA, Manifest.permission.READ_CONTACTS, Manifest.permission.RECORD_AUDIO);
+        	@Override public void onPermissionsChecked(MultiplePermissionsReport report) {/* ... */}
+        	@Override public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions, PermissionToken token) {/* ... */}
+        }, permissions);
 ```
 
 The ``MultiplePermissionsReport`` contains all the details of the permission request like the list of denied/granted permissions or utility methods like ``areAllPermissionsGranted`` and ``isAnyPermissionPermanentlyDenied``.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Dexter.checkPermission(new CompositePermissionListener(snackbarPermissionListene
 If you want to request multiple permissions you just need to do the same but registering an implementation of ``MultiplePermissionsListener``:
 
 ```java
-Collection<String> permissions = Arrays.asList(
 Dexter.checkPermissions(new MultiplePermissionsListener() {
     @Override public void onPermissionsChecked(MultiplePermissionsReport report) {/* ... */}
     @Override public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions, PermissionToken token) {/* ... */}


### PR DESCRIPTION
The sample given for Multiple permissions was broken. The compiler doesn't like doing Dexter.checkPermission inline because it has no return value. (This might have changed with a new version of Dexter?).

Creating the permission list separately solved it.