### PR TITLE
Fix race condition

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -185,6 +185,7 @@ final class DexterInstance {
 
   private PermissionStates getPermissionStates(Collection<String> pendingPermissions) {
     PermissionStates permissionStates = new PermissionStates();
+
     for (String permission : pendingPermissions) {
       int permissionState = androidPermissionService.checkSelfPermission(activity, permission);
       switch (permissionState) {
@@ -197,6 +198,7 @@ final class DexterInstance {
           break;
       }
     }
+
     return permissionStates;
   }
 
@@ -250,7 +252,7 @@ final class DexterInstance {
       return;
     }
 
-    synchronized(pendingPermissionsMutex) {
+    synchronized (pendingPermissionsMutex) {
       pendingPermissions.removeAll(permissions);
       if (pendingPermissions.isEmpty()) {
         activity.finish();


### PR DESCRIPTION
There is a race condition causing crashes in some situations.

The flow is the following:

1. Begin `continuePendingRequestIfPossible`
2. `pendingPermissions` is NOT empty
3. `rationaleAccepted` has NOT been accepted
4. --- Previous thread executes `onPermissionsChecked`
5. --- Clean pending permissions, rationaleAccepted and all internal state, including `this.activity`
6. Call `onActivityReady` with `this.activity`
7. `androidPermissionService.checkSelfPermission(activity, permission);` causes a NPE

Solution: Create a mutex separating execution of two critical snippets, the one cleaning the activity and the one using it to check for permissions.