### PR TITLE
Dexter lifecycle sample

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: android
 android:
   components:
     - tools
-    - build-tools-23.0.2
+    - build-tools-23.0.3
     - android-23
     - extra-android-support
     - extra-google-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,3 @@ android:
 
 script:
   - ./gradlew checkstyle build
-  - cat /home/travis/build/Karumi/Dexter/dexter/build/outputs/lint-results-debug.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ android:
     - tools
     - build-tools-23.0.3
     - android-23
+    - platform-tools
     - extra-android-support
     - extra-google-m2repository
     - extra-android-m2repository

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,5 @@ android:
     - extra-android-m2repository
 
 script:
-  ./gradlew checkstyle build
-  cat /home/travis/build/Karumi/Dexter/dexter/build/outputs/lint-results-debug.xml
+  - ./gradlew checkstyle build
+  - cat /home/travis/build/Karumi/Dexter/dexter/build/outputs/lint-results-debug.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ android:
 
 script:
   ./gradlew checkstyle build
+  cat /home/travis/build/Karumi/Dexter/dexter/build/outputs/lint-results-debug.xml

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:1.3.0'
+    classpath 'com.android.tools.build:gradle:2.1.0'
   }
 }
 

--- a/dexter/build.gradle
+++ b/dexter/build.gradle
@@ -3,7 +3,7 @@ apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn
 
 android {
   compileSdkVersion 23
-  buildToolsVersion "23.0.2"
+  buildToolsVersion "23.0.3"
 
   defaultConfig {
     minSdkVersion 10
@@ -20,8 +20,8 @@ android {
 
 dependencies {
   compile fileTree(dir: 'libs', include: ['*.jar'])
-  compile 'com.android.support:appcompat-v7:23.2.1'
-  compile 'com.android.support:design:23.2.1'
+  compile 'com.android.support:appcompat-v7:23.4.0'
+  compile 'com.android.support:design:23.4.0'
   testCompile 'junit:junit:4.12'
   testCompile "org.mockito:mockito-core:1.9.5"
 }

--- a/dexter/src/main/AndroidManifest.xml
+++ b/dexter/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.karumi.dexter"
+    android:allowBackup="true"
     >
 
   <application>

--- a/dexter/src/main/res/values/strings.xml
+++ b/dexter/src/main/res/values/strings.xml
@@ -15,5 +15,4 @@
   ~ limitations under the License.
   -->
 <resources>
-  <string name="app_name">Dexter</string>
 </resources>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 12 18:14:23 CET 2015
+#Tue May 31 18:57:50 CEST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 23
-  buildToolsVersion "23.0.2"
+  buildToolsVersion "23.0.3"
 
   defaultConfig {
     applicationId "com.karumi.dexter.sample"
@@ -20,7 +20,7 @@ android {
 
 dependencies {
   compile fileTree(include: ['*.jar'], dir: 'libs')
-  compile 'com.android.support:appcompat-v7:23.1.1'
+  compile 'com.android.support:appcompat-v7:23.4.0'
   compile 'com.jakewharton:butterknife:7.0.1'
   compile project(':dexter')
 }

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.karumi.dexter.sample"
-    >
+>
 
   <uses-permission android:name="android.permission.CAMERA"/>
   <uses-permission android:name="android.permission.READ_CONTACTS"/>
@@ -29,11 +29,15 @@
       android:icon="@mipmap/ic_logo_karumi"
       android:supportsRtl="true"
       android:theme="@style/AppTheme"
-      >
+  >
 
     <activity
         android:name=".SampleActivity"
-        >
+    />
+
+    <activity
+        android:name=".ChooserActivity"
+    >
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>
         <category android:name="android.intent.category.LAUNCHER"/>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -37,6 +37,9 @@
     <activity
         android:name=".OnCreateSampleActivity"
     />
+    <activity
+        android:name=".ApplicationSampleActivity"
+    />
 
     <activity
         android:name=".ChooserActivity"

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -34,6 +34,9 @@
     <activity
         android:name=".SampleActivity"
     />
+    <activity
+        android:name=".OnCreateSampleActivity"
+    />
 
     <activity
         android:name=".ChooserActivity"

--- a/sample/src/main/java/com/karumi/dexter/sample/ApplicationSampleActivity.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/ApplicationSampleActivity.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Karumi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.karumi.dexter.sample;
+
+import android.app.Activity;
+import android.os.Bundle;
+import butterknife.ButterKnife;
+
+/**
+ * Activity to show if Dexter works when have been invoked from the application.
+ */
+public class ApplicationSampleActivity extends Activity {
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.application_sample_activity);
+    ButterKnife.bind(this);
+  }
+
+}

--- a/sample/src/main/java/com/karumi/dexter/sample/ChooserActivity.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/ChooserActivity.java
@@ -17,6 +17,10 @@
 package com.karumi.dexter.sample;
 
 import android.app.Activity;
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
 import android.os.Bundle;
 import butterknife.ButterKnife;
 import butterknife.OnClick;
@@ -25,6 +29,10 @@ import butterknife.OnClick;
  * Activity to choose applications options.
  */
 public class ChooserActivity extends Activity {
+
+  private static final int TIME_TO_RESTART = 50;
+  private static final int INTENT_RESTART_ID = 1234;
+
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.chooser_activity);
@@ -39,5 +47,24 @@ public class ChooserActivity extends Activity {
   @OnClick(R.id.bt_oncreate_sample)
   public void openOncreateSample() {
     OnCreateSampleActivity.open(this);
+  }
+
+  @OnClick(R.id.bt_application_sample)
+  public void openApplicationSample() {
+    DexterApplicationMode.enable(this);
+    relaunchApplicationToSample();
+  }
+
+  private void relaunchApplicationToSample() {
+    Intent intentRestart = new Intent(this, ApplicationSampleActivity.class);
+    PendingIntent pendingIntent = PendingIntent.getActivity(this, INTENT_RESTART_ID, intentRestart,
+        PendingIntent.FLAG_CANCEL_CURRENT);
+    AlarmManager alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
+    alarmManager.set(AlarmManager.RTC, System.currentTimeMillis() + TIME_TO_RESTART, pendingIntent);
+    closeApplication();
+  }
+
+  private void closeApplication() {
+    System.exit(0);
   }
 }

--- a/sample/src/main/java/com/karumi/dexter/sample/ChooserActivity.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/ChooserActivity.java
@@ -22,7 +22,7 @@ import butterknife.ButterKnife;
 import butterknife.OnClick;
 
 /**
- *  Activity to choose applications options.
+ * Activity to choose applications options.
  */
 public class ChooserActivity extends Activity {
   @Override protected void onCreate(Bundle savedInstanceState) {
@@ -34,5 +34,10 @@ public class ChooserActivity extends Activity {
   @OnClick(R.id.bt_common_sample)
   public void openCommonSample() {
     SampleActivity.open(this);
+  }
+
+  @OnClick(R.id.bt_oncreate_sample)
+  public void openOncreateSample() {
+    OnCreateSampleActivity.open(this);
   }
 }

--- a/sample/src/main/java/com/karumi/dexter/sample/ChooserActivity.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/ChooserActivity.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2015 Karumi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.karumi.dexter.sample;
+
+import android.app.Activity;
+import android.os.Bundle;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+
+/**
+ *  Activity to choose applications options.
+ */
+public class ChooserActivity extends Activity {
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.chooser_activity);
+    ButterKnife.bind(this);
+  }
+
+  @OnClick(R.id.bt_common_sample)
+  public void openCommonSample() {
+    SampleActivity.open(this);
+  }
+}

--- a/sample/src/main/java/com/karumi/dexter/sample/DexterApplicationMode.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/DexterApplicationMode.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright (C) 2016 Karumi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.karumi.dexter.sample;
 
 import android.content.Context;

--- a/sample/src/main/java/com/karumi/dexter/sample/DexterApplicationMode.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/DexterApplicationMode.java
@@ -1,0 +1,31 @@
+package com.karumi.dexter.sample;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+
+public class DexterApplicationMode {
+
+  public static final String APPLICATION_SETTING = "applicationSetting";
+  private static final String IS_ENABLE = "IS_ENABLE";
+
+  public static boolean isEnable(Context context) {
+    SharedPreferences sharedpreferences = getSharedPreferences(context);
+    return sharedpreferences.getBoolean(IS_ENABLE, false);
+  }
+
+  public static void clear(Context context) {
+    SharedPreferences sharedpreferences = getSharedPreferences(context);
+    sharedpreferences.edit().clear().commit();
+  }
+
+  public static void enable(Context context) {
+    SharedPreferences sharedpreferences = getSharedPreferences(context);
+    SharedPreferences.Editor editor = sharedpreferences.edit();
+    editor.putBoolean(IS_ENABLE, true);
+    editor.commit();
+  }
+
+  private static SharedPreferences getSharedPreferences(Context context) {
+    return context.getSharedPreferences(APPLICATION_SETTING, Context.MODE_PRIVATE);
+  }
+}

--- a/sample/src/main/java/com/karumi/dexter/sample/OnCreateSampleActivity.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/OnCreateSampleActivity.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2016 Karumi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.karumi.dexter.sample;
+
+import android.Manifest;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import butterknife.Bind;
+import butterknife.ButterKnife;
+import com.karumi.dexter.Dexter;
+import com.karumi.dexter.PermissionToken;
+import com.karumi.dexter.listener.PermissionDeniedResponse;
+import com.karumi.dexter.listener.PermissionGrantedResponse;
+import com.karumi.dexter.listener.PermissionRequest;
+import com.karumi.dexter.listener.single.CompositePermissionListener;
+import com.karumi.dexter.listener.single.PermissionListener;
+import com.karumi.dexter.listener.single.SnackbarOnDeniedPermissionListener;
+
+/**
+ * Activity to show if Dexter works when have been invoked from onCreate.
+ */
+public class OnCreateSampleActivity extends Activity {
+
+  @Bind(android.R.id.content) ViewGroup rootView;
+  @Bind(R.id.contacts_permission_feedback) TextView feedbackView;
+
+  private PermissionListener cameraPermissionListener;
+
+  @Override protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    setContentView(R.layout.oncreate_sample_activity);
+    ButterKnife.bind(this);
+    createPermissionListeners();
+    requestPermission();
+  }
+
+  private void requestPermission() {
+    if (Dexter.isRequestOngoing()) {
+      return;
+    }
+    Dexter.checkPermission(cameraPermissionListener, Manifest.permission.CAMERA);
+  }
+
+  private void createPermissionListeners() {
+
+    cameraPermissionListener =
+        new CompositePermissionListener(feedbackViewPermissionListener,
+            SnackbarOnDeniedPermissionListener.Builder.with(rootView,
+                R.string.camera_permission_denied_feedback)
+                .withOpenSettingsButton(R.string.permission_rationale_settings_button_text)
+                .build());
+  }
+
+  private PermissionListener feedbackViewPermissionListener = new PermissionListener() {
+    @Override public void onPermissionGranted(PermissionGrantedResponse response) {
+      setFeedback(getString(R.string.permission_granted_feedback));
+    }
+
+    @Override public void onPermissionDenied(PermissionDeniedResponse response) {
+      setFeedback(getString(R.string.permission_denied_feedback));
+    }
+
+    @Override public void onPermissionRationaleShouldBeShown(PermissionRequest permission,
+        PermissionToken token) {
+    }
+  };
+
+  private void setFeedback(String feedback) {
+    String feedbackCompose = getString(R.string.feedback_permission_on_create) + " "
+        + feedback;
+    feedbackView.setText(feedbackCompose);
+  }
+
+  public static void open(Context context) {
+    Intent intent = new Intent(context, OnCreateSampleActivity.class);
+    context.startActivity(intent);
+  }
+}

--- a/sample/src/main/java/com/karumi/dexter/sample/SampleActivity.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/SampleActivity.java
@@ -20,7 +20,9 @@ import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.content.ContextCompat;
@@ -185,5 +187,10 @@ public class SampleActivity extends Activity {
     }
 
     return feedbackView;
+  }
+
+  public static void open(Context context) {
+    Intent intent = new Intent(context, SampleActivity.class);
+    context.startActivity(intent);
   }
 }

--- a/sample/src/main/java/com/karumi/dexter/sample/SampleApplication.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/SampleApplication.java
@@ -16,8 +16,10 @@
 
 package com.karumi.dexter.sample;
 
+import android.Manifest;
 import android.app.Application;
 import com.karumi.dexter.Dexter;
+import com.karumi.dexter.listener.single.EmptyPermissionListener;
 
 /**
  * Sample application that initializes the Dexter library.
@@ -27,5 +29,14 @@ public class SampleApplication extends Application {
   @Override public void onCreate() {
     super.onCreate();
     Dexter.initialize(this);
+    boolean launchDexterOnApplication = DexterApplicationMode.isEnable(this);
+    if (launchDexterOnApplication) {
+      DexterApplicationMode.clear(this);
+      requestDexterOnApplication();
+    }
+  }
+
+  private void requestDexterOnApplication() {
+    Dexter.checkPermission(new EmptyPermissionListener(), Manifest.permission.RECORD_AUDIO);
   }
 }

--- a/sample/src/main/res/layout/application_sample_activity.xml
+++ b/sample/src/main/res/layout/application_sample_activity.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 Karumi.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorPrimaryDark"
+    >
+
+  <include layout="@layout/header"/>
+
+
+  <TextView
+      android:id="@+id/contacts_permission_feedback"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_centerInParent="true"
+      android:text="@string/feedback_permission_on_application"
+      style="@style/PermissionFeedback"
+      />
+
+</RelativeLayout>

--- a/sample/src/main/res/layout/chooser_activity.xml
+++ b/sample/src/main/res/layout/chooser_activity.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2016 Karumi.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorPrimaryDark"
+    >
+
+  <include layout="@layout/header"/>
+
+  <Button
+      android:id="@+id/bt_oncreate_sample"
+      android:layout_width="@dimen/button_width"
+      android:layout_height="@dimen/button_height"
+      android:text="@string/oncreate_sample_title"
+      android:layout_centerInParent="true"
+      style="@style/PermissionButton"
+      />
+
+  <Button
+      android:id="@+id/bt_common_sample"
+      android:layout_width="@dimen/button_width"
+      android:layout_height="@dimen/button_height"
+      android:text="@string/common_sample_title"
+      android:layout_above="@id/bt_oncreate_sample"
+      android:layout_centerHorizontal="true"
+      style="@style/PermissionButton"
+      />
+
+  <Button
+      android:id="@+id/bt_application_sample"
+      android:layout_width="@dimen/button_width"
+      android:layout_height="@dimen/button_height"
+      android:text="@string/application_sample_title"
+      android:layout_below="@id/bt_oncreate_sample"
+      android:layout_centerHorizontal="true"
+      style="@style/PermissionButton"
+      />
+
+
+</RelativeLayout>

--- a/sample/src/main/res/layout/chooser_activity.xml
+++ b/sample/src/main/res/layout/chooser_activity.xml
@@ -44,8 +44,10 @@
 
   <Button
       android:id="@+id/bt_application_sample"
-      android:layout_width="@dimen/button_width"
-      android:layout_height="@dimen/button_height"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_marginLeft="@dimen/min_button_margin"
+      android:layout_marginRight="@dimen/min_button_margin"
       android:text="@string/application_sample_title"
       android:layout_below="@id/bt_oncreate_sample"
       android:layout_centerHorizontal="true"

--- a/sample/src/main/res/layout/oncreate_sample_activity.xml
+++ b/sample/src/main/res/layout/oncreate_sample_activity.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (C) 2015 Karumi.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorPrimaryDark"
+    >
+
+  <include layout="@layout/header"/>
+
+
+  <TextView
+      android:id="@+id/contacts_permission_feedback"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:layout_centerInParent="true"
+      android:text="@string/feedback_permission_on_create"
+      style="@style/PermissionFeedback"
+      />
+
+</RelativeLayout>

--- a/sample/src/main/res/values/dimens.xml
+++ b/sample/src/main/res/values/dimens.xml
@@ -27,4 +27,5 @@
   <dimen name="feedback_height">@dimen/button_height</dimen>
   <dimen name="feedback_margin_left">10dp</dimen>
   <dimen name="all_permission_button_margin_right">10dp</dimen>
+  <dimen name="min_button_margin">60dp</dimen>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -24,16 +24,31 @@
   <string name="permission_denied_feedback">DENIED</string>
   <string name="permission_permanently_denied_feedback">PERMANENTLY DENIED</string>
   <string name="permission_unknown_feedback">UNKNOWN</string>
-  <string name="all_permissions_denied_feedback">All those permissions are needed for doing some magic</string>
-  <string name="camera_permission_denied_feedback">Camera permission is needed for doing some magic</string>
-  <string name="contacts_permission_denied_feedback">Contacts permission is needed for doing some magic</string>
+  <string name="all_permissions_denied_feedback">All those permissions are needed for doing some
+    magic
+  </string>
+  <string name="camera_permission_denied_feedback">Camera permission is needed for doing some
+    magic
+  </string>
+  <string name="contacts_permission_denied_feedback">Contacts permission is needed for doing some
+    magic
+  </string>
   <string name="audio_permission_denied_dialog_title">Audio permission request</string>
-  <string name="audio_permission_denied_dialog_feedback">Audio recording will not be available until you accept the permission request</string>
+  <string name="audio_permission_denied_dialog_feedback">Audio recording will not be available until
+    you accept the permission request
+  </string>
   <string name="permission_rationale_title">We need this permission</string>
-  <string name="permission_rationale_message">This permission is needed for doing some fancy stuff so please, allow it!</string>
+  <string name="permission_rationale_message">This permission is needed for doing some fancy stuff
+    so please, allow it!
+  </string>
   <string name="permission_rationale_settings_button_text">SETTINGS</string>
   <string name="common_sample_title">Sample</string>
   <string name="oncreate_sample_title">onCreate sample</string>
-  <string name="application_sample_title">Application sample</string>
+  <string name="application_sample_title">Application sample \n(this will reset the app. Don\'t be
+    afraid)
+  </string>
   <string name="feedback_permission_on_create">Testing camera permission in on create:</string>
+  <string name="feedback_permission_on_application">This is a test of invoke permission on
+    application.
+  </string>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -35,4 +35,5 @@
   <string name="common_sample_title">Sample</string>
   <string name="oncreate_sample_title">onCreate sample</string>
   <string name="application_sample_title">Application sample</string>
+  <string name="feedback_permission_on_create">Testing camera permission in on create:</string>
 </resources>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -32,4 +32,7 @@
   <string name="permission_rationale_title">We need this permission</string>
   <string name="permission_rationale_message">This permission is needed for doing some fancy stuff so please, allow it!</string>
   <string name="permission_rationale_settings_button_text">SETTINGS</string>
+  <string name="common_sample_title">Sample</string>
+  <string name="oncreate_sample_title">onCreate sample</string>
+  <string name="application_sample_title">Application sample</string>
 </resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -35,6 +35,7 @@
     <item name="android:textSize">@dimen/button_text_size</item>
     <item name="android:layout_marginTop">@dimen/permission_button_margin_vertical</item>
     <item name="android:layout_marginBottom">@dimen/permission_button_margin_vertical</item>
+    <item name="android:padding">@dimen/all_permission_button_margin_right</item>
   </style>
 
   <style name="PermissionFeedback">


### PR DESCRIPTION
- change the main screen for chooser screen where you can select the sample to run.
- add sample that test request permission in onCreate.
- add sample that test request on application initialize.

I've found that if you request Dexter from application and you use a Dialog, the dialog crash because the window doesn't exisit. We need talk about witch solution we are going to give to this one.
