### PR TITLE
Add support for Snackbar.Callback to permission listeners

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ PermissionListener snackbarPermissionListener =
             }
             @Override
             public void onDismissed(Snackbar snackbar, int event) {
-                // Event handler for when the given Snackbar is visible.
+                // Event handler for when the given Snackbar is visible
             }
         })
 		.build();

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ PermissionListener snackbarPermissionListener =
 	SnackbarOnDeniedPermissionListener.Builder
 		.with(rootView, "Camera access is needed to take pictures of your dog")
 		.withOpenSettingsButton("Settings")
+        .withCallback(new Snackbar.Callback() {
+            @Override
+            public void onShown(Snackbar snackbar) {
+                // Event handler for when the given Snackbar has been dismissed
+            }
+            @Override
+            public void onDismissed(Snackbar snackbar, int event) {
+                // Event handler for when the given Snackbar is visible.
+            }
+        })
 		.build();
 Dexter.checkPermission(snackbarPermissionListener, Manifest.permission.CAMERA);
 ```
@@ -114,6 +124,16 @@ MultiplePermissionsListener snackbarMultiplePermissionsListener =
 	SnackbarOnAnyDeniedMultiplePermissionsListener.Builder
 		.with(rootView, "Camera and audio access is needed to take pictures of your dog")
 		.withOpenSettingsButton("Settings")
+        .withCallback(new Snackbar.Callback() {
+            @Override
+            public void onShown(Snackbar snackbar) {
+                // Event handler for when the given Snackbar has been dismissed
+            }
+            @Override
+            public void onDismissed(Snackbar snackbar, int event) {
+                // Event handler for when the given Snackbar is visible
+            }
+        })
 		.build();
 Dexter.checkPermissions(snackbarMultiplePermissionsListener, Manifest.permission.CAMERA, Manifest.permission.READ_CONTACTS, Manifest.permission.RECORD_AUDIO);
 ```

--- a/dexter/src/main/java/com/karumi/dexter/listener/multi/SnackbarOnAnyDeniedMultiplePermissionsListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/multi/SnackbarOnAnyDeniedMultiplePermissionsListener.java
@@ -36,6 +36,7 @@ public class SnackbarOnAnyDeniedMultiplePermissionsListener extends EmptyMultipl
   private final String text;
   private final String buttonText;
   private final View.OnClickListener onButtonClickListener;
+  private final Snackbar.Callback snackbarCallback;
 
   /**
    * @param rootView Parent view to show the snackbar
@@ -44,11 +45,12 @@ public class SnackbarOnAnyDeniedMultiplePermissionsListener extends EmptyMultipl
    * @param onButtonClickListener Action performed when the user clicks the snackbar button
    */
   private SnackbarOnAnyDeniedMultiplePermissionsListener(ViewGroup rootView, String text,
-      String buttonText, View.OnClickListener onButtonClickListener) {
+      String buttonText, View.OnClickListener onButtonClickListener, Snackbar.Callback snackbarCallback) {
     this.rootView = rootView;
     this.text = text;
     this.buttonText = buttonText;
     this.onButtonClickListener = onButtonClickListener;
+    this.snackbarCallback = snackbarCallback;
   }
 
   @Override public void onPermissionsChecked(MultiplePermissionsReport report) {
@@ -64,6 +66,9 @@ public class SnackbarOnAnyDeniedMultiplePermissionsListener extends EmptyMultipl
     if (buttonText != null && onButtonClickListener != null) {
       snackbar.setAction(buttonText, onButtonClickListener);
     }
+    if (snackbarCallback != null) {
+      snackbar.setCallback(snackbarCallback);
+    }
     snackbar.show();
   }
 
@@ -76,6 +81,7 @@ public class SnackbarOnAnyDeniedMultiplePermissionsListener extends EmptyMultipl
     private final String text;
     private String buttonText;
     private View.OnClickListener onClickListener;
+    private Snackbar.Callback snackbarCallback;
 
     private Builder(ViewGroup rootView, String text) {
       this.rootView = rootView;
@@ -133,10 +139,19 @@ public class SnackbarOnAnyDeniedMultiplePermissionsListener extends EmptyMultipl
     }
 
     /**
+     * Adds a callback to handle the snackbar {@code onDismissed} and {@code onShown} events.
+     */
+    public Builder withCallback(Snackbar.Callback callback) {
+      this.snackbarCallback = callback;
+      return this;
+    }
+
+    /**
      * Builds a new instance of {@link SnackbarOnAnyDeniedMultiplePermissionsListener}
      */
     public SnackbarOnAnyDeniedMultiplePermissionsListener build() {
-      return new SnackbarOnAnyDeniedMultiplePermissionsListener(rootView, text, buttonText, onClickListener);
+      return new SnackbarOnAnyDeniedMultiplePermissionsListener(rootView, text, buttonText, onClickListener,
+              snackbarCallback);
     }
   }
 }

--- a/dexter/src/main/java/com/karumi/dexter/listener/single/SnackbarOnDeniedPermissionListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/single/SnackbarOnDeniedPermissionListener.java
@@ -36,6 +36,7 @@ public class SnackbarOnDeniedPermissionListener extends EmptyPermissionListener 
   private final String text;
   private final String buttonText;
   private final View.OnClickListener onButtonClickListener;
+  private final Snackbar.Callback snackbarCallback;
 
   /**
    * @param rootView Parent view to show the snackbar
@@ -44,11 +45,12 @@ public class SnackbarOnDeniedPermissionListener extends EmptyPermissionListener 
    * @param onButtonClickListener Action performed when the user clicks the snackbar button
    */
   private SnackbarOnDeniedPermissionListener(ViewGroup rootView, String text, String buttonText,
-      View.OnClickListener onButtonClickListener) {
+      View.OnClickListener onButtonClickListener, Snackbar.Callback snackbarCallback) {
     this.rootView = rootView;
     this.text = text;
     this.buttonText = buttonText;
     this.onButtonClickListener = onButtonClickListener;
+    this.snackbarCallback = snackbarCallback;
   }
 
   @Override public void onPermissionDenied(PermissionDeniedResponse response) {
@@ -57,6 +59,9 @@ public class SnackbarOnDeniedPermissionListener extends EmptyPermissionListener 
     Snackbar snackbar = Snackbar.make(rootView, text, Snackbar.LENGTH_LONG);
     if (buttonText != null && onButtonClickListener != null) {
       snackbar.setAction(buttonText, onButtonClickListener);
+    }
+    if (snackbarCallback != null) {
+      snackbar.setCallback(snackbarCallback);
     }
     snackbar.show();
   }
@@ -70,6 +75,7 @@ public class SnackbarOnDeniedPermissionListener extends EmptyPermissionListener 
     private final String text;
     private String buttonText;
     private View.OnClickListener onClickListener;
+    private Snackbar.Callback snackbarCallback;
 
     private Builder(ViewGroup rootView, String text) {
       this.rootView = rootView;
@@ -127,10 +133,18 @@ public class SnackbarOnDeniedPermissionListener extends EmptyPermissionListener 
     }
 
     /**
+     * Adds a callback to handle the snackbar {@code onDismissed} and {@code onShown} events.
+     */
+    public Builder withCallback(Snackbar.Callback callback) {
+      this.snackbarCallback = callback;
+      return this;
+    }
+
+    /**
      * Builds a new instance of {@link SnackbarOnDeniedPermissionListener}
      */
     public SnackbarOnDeniedPermissionListener build() {
-      return new SnackbarOnDeniedPermissionListener(rootView, text, buttonText, onClickListener);
+      return new SnackbarOnDeniedPermissionListener(rootView, text, buttonText, onClickListener, snackbarCallback);
     }
   }
 }

--- a/sample/src/main/java/com/karumi/dexter/sample/SampleActivity.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/SampleActivity.java
@@ -23,6 +23,7 @@ import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.view.ViewGroup;
 import android.widget.TextView;
@@ -153,6 +154,16 @@ public class SampleActivity extends Activity {
         SnackbarOnDeniedPermissionListener.Builder.with(rootView,
             R.string.contacts_permission_denied_feedback)
             .withOpenSettingsButton(R.string.permission_rationale_settings_button_text)
+            .withCallback(new Snackbar.Callback() {
+              @Override
+              public void onShown(Snackbar snackbar) {
+                super.onShown(snackbar);
+              }
+              @Override
+              public void onDismissed(Snackbar snackbar, int event) {
+                super.onDismissed(snackbar, event);
+              }
+            })
             .build());
 
     PermissionListener dialogOnDeniedPermissionListener =


### PR DESCRIPTION
This somewhat closes issue #66.

The issue was about giving complete access to the `Snackbar` instance but that would probably take a major refactor for which I don't have the time :( Instead, I'm just adding support for the `Snackbar.Callback` adding a `withCallback` method to the `Snackbar.Builder`.

I'm not sure if the updated README and/or the sample activity changes are satisfactory. If not, let me know how you want it. Also, I wasn't able to run `gradlew build`, it gave me some Javadoc errors which I'm not sure how to fix. Nor I know how to run a Travis CI build from my own branch.

I believe everything is working properly, it was just a simple change. But please let me know how can I achieve the final steps to get this fully tested and eventually accepted :)