### PR TITLE
Fix bug related to the recently deprecated ``initialize`` method.

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -17,9 +17,11 @@
 package com.karumi.dexter;
 
 import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+
 import com.karumi.dexter.listener.PermissionDeniedResponse;
 import com.karumi.dexter.listener.PermissionGrantedResponse;
 import com.karumi.dexter.listener.PermissionRequest;
@@ -208,12 +210,16 @@ final class DexterInstance {
   }
 
   private void startTransparentActivityIfNeeded() {
-    if (context.get() == null) {
+    Context context = this.context.get();
+    if (context == null) {
       return;
     }
 
-    Intent intent = intentProvider.get(context.get(), DexterActivity.class);
-    context.get().startActivity(intent);
+    Intent intent = intentProvider.get(context, DexterActivity.class);
+    if (context instanceof Application) {
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    }
+    context.startActivity(intent);
   }
 
   private void handleDeniedPermissions(Collection<String> permissions) {


### PR DESCRIPTION
Fix #76.

To be able to support the functionality related to the new deprecated  initialize method we need to check if the context is an instance of ``Application`` or not. If the context is an instance of ``Application`` then we have to add the famous ``NEW_TASK`` flag to the intent :)