### PR TITLE
Decouple relationship between Context setter and Dexter constructor.

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -126,9 +126,10 @@ public final class Dexter
     if (instance == null) {
       AndroidPermissionService androidPermissionService = new AndroidPermissionService();
       IntentProvider intentProvider = new IntentProvider();
-      instance = new DexterInstance(androidPermissionService, intentProvider);
+      instance = new DexterInstance(context, androidPermissionService, intentProvider);
+    } else {
+      instance.setContext(context);
     }
-    instance.setContext(context);
   }
 
   /**

--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -58,7 +58,7 @@ final class DexterInstance {
   private Activity activity;
   private MultiplePermissionsListener listener = EMPTY_LISTENER;
 
-  DexterInstance(AndroidPermissionService androidPermissionService,
+  DexterInstance(Context context, AndroidPermissionService androidPermissionService,
       IntentProvider intentProvider) {
     this.androidPermissionService = androidPermissionService;
     this.intentProvider = intentProvider;
@@ -67,6 +67,7 @@ final class DexterInstance {
     this.isRequestingPermission = new AtomicBoolean();
     this.rationaleAccepted = new AtomicBoolean();
     this.isShowingNativeDialog = new AtomicBoolean();
+    setContext(context);
   }
 
   void setContext(Context context) {

--- a/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
+++ b/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
@@ -66,8 +66,7 @@ import static org.mockito.Mockito.when;
     Context mockApplicationContext = mock(Context.class);
     when(context.getApplicationContext()).thenReturn(mockApplicationContext);
     asyncExecutor = new AsyncExecutor();
-    dexter = new DexterInstance(androidPermissionService, intentProvider);
-    dexter.setContext(context);
+    dexter = new DexterInstance(context, androidPermissionService, intentProvider);
   }
 
   @Test(expected = DexterException.class) public void onNoPermissionCheckedThenThrowException() {


### PR DESCRIPTION
Context: https://github.com/lianghanzhen/Dexter/commit/04cf8aa5108a3b9ef62ab686038e00db782388d4

As can be spotted on the previous PR, we introduced a coupling between the Dexter's constructor and the Context setter it has. Every time you build a Dexter instance, you have to call the setter to pass around the given context.

We can reuse the previous constructor, so that "dependency" is not required but we'll offer the setter to update that Context when needed.