### PR TITLE
Check for nullability of `instance` to avoid NPEs

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -137,7 +137,13 @@ public final class Dexter
    * used.
    */
   static void onActivityReady(Activity activity) {
-    instance.onActivityReady(activity);
+    /* Check against null values because sometimes the DexterActivity can call these internal
+       methods when the DexterInstance has been cleaned up.
+       Refer to this commit message for a more detailed explanation of the issue.
+     */
+    if (instance != null) {
+      instance.onActivityReady(activity);
+    }
   }
 
   /**
@@ -150,7 +156,13 @@ public final class Dexter
    */
   static void onPermissionsRequested(Collection<String> grantedPermissions,
       Collection<String> deniedPermissions) {
-    instance.onPermissionRequestGranted(grantedPermissions);
-    instance.onPermissionRequestDenied(deniedPermissions);
+    /* Check against null values because sometimes the DexterActivity can call these internal
+       methods when the DexterInstance has been cleaned up.
+       Refer to this commit message for a more detailed explanation of the issue.
+     */
+    if (instance != null) {
+      instance.onPermissionRequestGranted(grantedPermissions);
+      instance.onPermissionRequestDenied(deniedPermissions);
+    }
   }
 }


### PR DESCRIPTION
* We have found some apps crashed due to a NPE in Dexter.
  The problem can be reproduced by following these steps:
    * Accept one permission
    * Request other permission and while the native dialog
      is on screen go to the settings page for your app
    * Manually change the previous accepted permission to
      denied
    * Open the application again and BOOM!
  This happens because Android will partially restart the
  app when changing permissions from the settings.
  DexterActivity will try to notify dexter of the changes
  and will find that the static instance has been cleaned up.
* The easiest solution for now is to just ignore events from
  the activity if the instance is null.