### PR TITLE
Remove continue asking permission on activity paused/resumed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,17 +173,6 @@ The most simple implementation of your ``onPermissionRationaleShouldBeShown`` me
 }
 ```
 
-###Screen rotation
-If your application has to support configuration changes based on screen rotation remember to add a call to ``Dexter`` in your Activity ``onCreate`` method as follows:
-
-```java
-@Override protected void onCreate(Bundle savedInstanceState) {
-	super.onCreate(savedInstanceState);
-	setContentView(R.layout.sample_activity);
-	Dexter.withActivity(this).continueRequestingPendingPermissions(permissionListener);
-}
-```
-
 ###Error handling
 If you think there is an error in your Dexter integration, just register a `PermissionRequestErrorListener` when calling Dexter: 
 

--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -33,10 +33,10 @@ import java.util.Collections;
  * You can use this class directly using the provided fluent API like:
  *
  * Dexter.withActivity(activity)
- * .withPermission(permission)
- * .withListener(listener)
- * .onSameThread()
- * .check()
+ *       .withPermission(permission)
+ *       .withListener(listener)
+ *       .onSameThread()
+ *       .check()
  */
 public final class Dexter
     implements DexterBuilder, DexterBuilder.Permission, DexterBuilder.SinglePermissionListener,

--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -33,10 +33,10 @@ import java.util.Collections;
  * You can use this class directly using the provided fluent API like:
  *
  * Dexter.withActivity(activity)
- *       .withPermission(permission)
- *       .withListener(listener)
- *       .onSameThread()
- *       .check()
+ * .withPermission(permission)
+ * .withListener(listener)
+ * .onSameThread()
+ * .check()
  */
 public final class Dexter
     implements DexterBuilder, DexterBuilder.Permission, DexterBuilder.SinglePermissionListener,
@@ -71,14 +71,6 @@ public final class Dexter
   public DexterBuilder.MultiPermissionListener withPermissions(Collection<String> permissions) {
     this.permissions = new ArrayList<>(permissions);
     return this;
-  }
-
-  @Override public void continueRequestingPendingPermissions(PermissionListener listener) {
-    instance.continuePendingRequestIfPossible(listener, ThreadFactory.makeMainThread());
-  }
-
-  @Override public void continueRequestingPendingPermissions(MultiplePermissionsListener listener) {
-    instance.continuePendingRequestsIfPossible(listener, ThreadFactory.makeMainThread());
   }
 
   @Override public DexterBuilder withListener(PermissionListener listener) {
@@ -144,6 +136,13 @@ public final class Dexter
     if (instance != null) {
       instance.onActivityReady(activity);
     }
+  }
+
+  /**
+   * Method called whenever the DexterActivity has been destroyed.
+   */
+  static void onActivityDestroyed() {
+    instance.onActivityDestroyed();
   }
 
   /**

--- a/dexter/src/main/java/com/karumi/dexter/DexterActivity.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterActivity.java
@@ -32,6 +32,11 @@ public final class DexterActivity extends Activity {
     getWindow().addFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE);
   }
 
+  @Override protected void onDestroy() {
+    super.onDestroy();
+    Dexter.onActivityDestroyed();
+  }
+
   @Override protected void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
     Dexter.onActivityReady(this);

--- a/dexter/src/main/java/com/karumi/dexter/DexterBuilder.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterBuilder.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package com.karumi.dexter;
 
 import com.karumi.dexter.listener.PermissionRequestErrorListener;
@@ -36,10 +35,6 @@ public interface DexterBuilder {
     DexterBuilder.MultiPermissionListener withPermissions(String... permissions);
 
     DexterBuilder.MultiPermissionListener withPermissions(Collection<String> permissions);
-
-    void continueRequestingPendingPermissions(PermissionListener listener);
-
-    void continueRequestingPendingPermissions(MultiplePermissionsListener listener);
   }
 
   interface SinglePermissionListener {

--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -99,29 +99,6 @@ final class DexterInstance {
   }
 
   /**
-   * Check if there is a permission pending to be confirmed by the user and restarts the
-   * request for permission process.
-   */
-  void continuePendingRequestIfPossible(PermissionListener listener, Thread thread) {
-    MultiplePermissionsListenerToPermissionListenerAdapter adapter =
-        new MultiplePermissionsListenerToPermissionListenerAdapter(listener);
-    continuePendingRequestsIfPossible(adapter, thread);
-  }
-
-  /**
-   * Check if there are some permissions pending to be confirmed by the user and restarts the
-   * request for permission process.
-   */
-  void continuePendingRequestsIfPossible(MultiplePermissionsListener listener, Thread thread) {
-    if (!pendingPermissions.isEmpty()) {
-      this.listener = new MultiplePermissionListenerThreadDecorator(listener, thread);
-      if (!rationaleAccepted.get()) {
-        onActivityReady(activity);
-      }
-    }
-  }
-
-  /**
    * Method called whenever the inner activity has been created or restarted and is ready to be
    * used.
    */
@@ -139,6 +116,13 @@ final class DexterInstance {
       handleDeniedPermissions(permissionStates.getDeniedPermissions());
       updatePermissionsAsGranted(permissionStates.getGrantedPermissions());
     }
+  }
+
+  /**
+   * Method called whenever the inner activity has been destroyed.
+   */
+  void onActivityDestroyed() {
+    isRequestingPermission.set(false);
   }
 
   /**

--- a/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
+++ b/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
@@ -131,16 +131,6 @@ import static org.mockito.Mockito.when;
     thenPermissionIsPermanentlyDenied(ANY_PERMISSION);
   }
 
-  @Test public void onPermissionsPendingThenShouldNotShowPermissionRationaleTwice() {
-    givenPermissionIsAlreadyDenied(ANY_PERMISSION);
-    givenShouldShowRationaleForPermission(ANY_PERMISSION);
-
-    whenCheckPermission(permissionListener, ANY_PERMISSION);
-    whenContinueWithTheCheckPermissionProcess(permissionListener);
-
-    thenPermissionRationaleIsShown(2);
-  }
-
   @Test public void onPermissionFailedByRuntimeExceptionThenNotifiesListener() {
     givenARuntimeExceptionIsThrownWhenPermissionIsChecked(ANY_PERMISSION);
     givenShouldShowRationaleForPermission(ANY_PERMISSION);
@@ -194,10 +184,6 @@ import static org.mockito.Mockito.when;
   private void whenCheckPermission(PermissionListener permissionListener, String permission) {
     dexter.checkPermission(permissionListener, permission, THREAD);
     dexter.onActivityReady(activity);
-  }
-
-  private void whenContinueWithTheCheckPermissionProcess(PermissionListener permissionListener) {
-    dexter.continuePendingRequestIfPossible(permissionListener, THREAD);
   }
 
   private void thenPermissionIsGranted(String permission) {

--- a/sample/src/main/java/com/karumi/dexter/sample/SampleActivity.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/SampleActivity.java
@@ -62,12 +62,6 @@ public class SampleActivity extends Activity {
     setContentView(R.layout.sample_activity);
     ButterKnife.bind(this);
     createPermissionListeners();
-    /*
-     * If during the screen rotation process the activity has been restarted you can call this
-     * method to start with the check permission process without keeping the state of the request
-     * permission process in an Android Bundle.
-     */
-    Dexter.withActivity(this).continueRequestingPendingPermissions(allPermissionsListener);
   }
 
   @OnClick(R.id.all_permissions_button) public void onAllPermissionsButtonClicked() {


### PR DESCRIPTION
As requested by some of our users and the team this PR fixes #113.

I've tested the sample app manually but I'm not really sure if the current implementation performs the expected effect. Could you double check the behavior when rotating the screen?

As this is a major breaking change we can release this PR in the future. If you want me to send a PR deprecating these two methods before to merge this PR just let me know.