### PR TITLE
Deprecate the feature we are going to remove in Dexter 4.0.0

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -73,10 +73,18 @@ public final class Dexter
     return this;
   }
 
+  /**
+   * @deprecated This method is going to be removed in the next major version.
+   */
+  @Deprecated
   @Override public void continueRequestingPendingPermissions(PermissionListener listener) {
     instance.continuePendingRequestIfPossible(listener, ThreadFactory.makeMainThread());
   }
 
+  /**
+   * @deprecated This method is going to be removed in the next major version.
+   */
+  @Deprecated
   @Override public void continueRequestingPendingPermissions(MultiplePermissionsListener listener) {
     instance.continuePendingRequestsIfPossible(listener, ThreadFactory.makeMainThread());
   }


### PR DESCRIPTION
Add @Deprecated annotations to the public API related to the continue requesting permissions feature. Please, merge this branch  and release a patch before to release Dexter 4.0.0 with the PR #113.