### PR TITLE
Deprecate EmptyListeners

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/listener/multi/BaseMultiplePermissionsListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/multi/BaseMultiplePermissionsListener.java
@@ -22,7 +22,7 @@ import com.karumi.dexter.listener.PermissionRequest;
 import java.util.List;
 
 /**
- * Empty implementation of {@link MultiplePermissionsListener} to allow extensions to implement
+ * Base implementation of {@link MultiplePermissionsListener} to allow extensions to implement
  * only the required methods
  */
 public class BaseMultiplePermissionsListener implements MultiplePermissionsListener {

--- a/dexter/src/main/java/com/karumi/dexter/listener/multi/BaseMultiplePermissionsListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/multi/BaseMultiplePermissionsListener.java
@@ -24,11 +24,8 @@ import java.util.List;
 /**
  * Empty implementation of {@link MultiplePermissionsListener} to allow extensions to implement
  * only the required methods
- * @deprecated Use {@link BaseMultiplePermissionsListener} instead that has a default implementation
- * for the method onPermissionRationaleShouldBeShown.
  */
-@Deprecated
-public class EmptyMultiplePermissionsListener implements MultiplePermissionsListener {
+public class BaseMultiplePermissionsListener implements MultiplePermissionsListener {
 
   @Override public void onPermissionsChecked(MultiplePermissionsReport report) {
 
@@ -36,6 +33,6 @@ public class EmptyMultiplePermissionsListener implements MultiplePermissionsList
 
   @Override public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions,
       PermissionToken token) {
-
+    token.continuePermissionRequest();
   }
 }

--- a/dexter/src/main/java/com/karumi/dexter/listener/single/BasePermissionListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/single/BasePermissionListener.java
@@ -22,7 +22,7 @@ import com.karumi.dexter.listener.PermissionGrantedResponse;
 import com.karumi.dexter.listener.PermissionRequest;
 
 /**
- * Empty implementation of {@link PermissionListener} to allow extensions to implement only the
+ * Base implementation of {@link PermissionListener} to allow extensions to implement only the
  * required methods
  */
 public class BasePermissionListener implements PermissionListener {

--- a/dexter/src/main/java/com/karumi/dexter/listener/single/BasePermissionListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/single/BasePermissionListener.java
@@ -14,28 +14,29 @@
  * limitations under the License.
  */
 
-package com.karumi.dexter.listener.multi;
+package com.karumi.dexter.listener.single;
 
-import com.karumi.dexter.MultiplePermissionsReport;
 import com.karumi.dexter.PermissionToken;
+import com.karumi.dexter.listener.PermissionDeniedResponse;
+import com.karumi.dexter.listener.PermissionGrantedResponse;
 import com.karumi.dexter.listener.PermissionRequest;
-import java.util.List;
 
 /**
- * Empty implementation of {@link MultiplePermissionsListener} to allow extensions to implement
- * only the required methods
- * @deprecated Use {@link BaseMultiplePermissionsListener} instead that has a default implementation
- * for the method onPermissionRationaleShouldBeShown.
+ * Empty implementation of {@link PermissionListener} to allow extensions to implement only the
+ * required methods
  */
-@Deprecated
-public class EmptyMultiplePermissionsListener implements MultiplePermissionsListener {
+public class BasePermissionListener implements PermissionListener {
 
-  @Override public void onPermissionsChecked(MultiplePermissionsReport report) {
+  @Override public void onPermissionGranted(PermissionGrantedResponse response) {
 
   }
 
-  @Override public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions,
-      PermissionToken token) {
+  @Override public void onPermissionDenied(PermissionDeniedResponse response) {
 
+  }
+
+  @Override public void onPermissionRationaleShouldBeShown(PermissionRequest permission,
+      PermissionToken token) {
+    token.continuePermissionRequest();
   }
 }

--- a/dexter/src/main/java/com/karumi/dexter/listener/single/EmptyPermissionListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/single/EmptyPermissionListener.java
@@ -24,7 +24,10 @@ import com.karumi.dexter.listener.PermissionRequest;
 /**
  * Empty implementation of {@link PermissionListener} to allow extensions to implement only the
  * required methods
+ * @deprecated Use {@link BasePermissionListener} instead that has a default implementation
+ * for the method onPermissionRationaleShouldBeShown.
  */
+@Deprecated
 public class EmptyPermissionListener implements PermissionListener {
 
   @Override public void onPermissionGranted(PermissionGrantedResponse response) {


### PR DESCRIPTION
We are releasing v4.0.0 with a default implementation of `onPermissionRationaleShouldBeShown` so that we don't have any more problems with reports like #64