### PR TITLE
Remove unnecessary and missing ci android component

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ android:
     - build-tools-25.0.0
     - platform-tools
     - android-25
-    - extra-android-support
     - extra-google-m2repository
     - extra-android-m2repository
 


### PR DESCRIPTION
Android support libraries are already included in extra-android-m2repository.

Current builds are failing to find the unnecessary extra-android-support component.