### PR TITLE
Dev use context

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Screenshots
 Usage
 -----
 
-To start using the library you just need to call `Dexter` with a valid `Activity`:
+To start using the library you just need to call `Dexter` with a valid `Context`:
 
 ```java
 public MyActivity extends Activity {
 	@Override public void onCreate() {
 		super.onCreate();
-		Dexter.withActivity(activity)
+		Dexter.withContext(this)
 			.withPermission(permission)
 			.withListener(listener)
 			.check();
@@ -36,7 +36,7 @@ public MyActivity extends Activity {
 For each permission, register a ``PermissionListener`` implementation to receive the state of the request:
 
 ```java
-Dexter.withActivity(this)
+Dexter.withContext(context)
 	.withPermission(Manifest.permission.CAMERA)
 	.withListener(new PermissionListener() {
 		@Override public void onPermissionGranted(PermissionGrantedResponse response) {/* ... */}
@@ -92,7 +92,7 @@ PermissionListener compositePermissionListener = new CompositePermissionListener
 If you want to request multiple permissions you just need to call `withPermissions` and register an implementation of ``MultiplePermissionsListener``:
 
 ```java
-Dexter.withActivity(this)
+Dexter.withContext(this)
 	.withPermissions(
 		Manifest.permission.CAMERA,
 		Manifest.permission.READ_CONTACTS,
@@ -153,7 +153,7 @@ MultiplePermissionsListener compositePermissionsListener = new CompositeMultiple
 If you want to receive permission listener callbacks on the same thread that fired the permission request, you just need to call ``onSameThread`` before checking for permissions:
 
 ```java
-Dexter.withActivity(activity)
+Dexter.withContext(context)
 	.withPermission(permission)
 	.withListener(listener)
 	.onSameThread()
@@ -177,7 +177,7 @@ The most simple implementation of your ``onPermissionRationaleShouldBeShown`` me
 If you think there is an error in your Dexter integration, just register a `PermissionRequestErrorListener` when calling Dexter:
 
 ```java
-Dexter.withActivity(activity)
+Dexter.withContext(context)
 	.withPermission(permission)
 	.withListener(listener)
 	.withErrorListener(new PermissionRequestErrorListener() {

--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -48,6 +48,7 @@ public final class Dexter
   private MultiplePermissionsListener listener = new BaseMultiplePermissionsListener();
   private PermissionRequestErrorListener errorListener = new EmptyPermissionRequestErrorListener();
   private boolean shouldExecuteOnSameThread = false;
+  private boolean shouldForcePermission = false;
 
   private Dexter(Activity activity) {
     initialize(activity);
@@ -88,6 +89,11 @@ public final class Dexter
     return this;
   }
 
+  @Override public DexterBuilder force() {
+    shouldForcePermission = true;
+    return this;
+  }
+
   @Override public DexterBuilder withErrorListener(PermissionRequestErrorListener errorListener) {
     this.errorListener = errorListener;
     return this;
@@ -96,7 +102,7 @@ public final class Dexter
   @Override public void check() {
     try {
       Thread thread = getThread();
-      instance.checkPermissions(listener, permissions, thread);
+      instance.checkPermissions(listener, permissions, thread, shouldForcePermission);
     } catch (DexterException e) {
       errorListener.onError(e.error);
     }

--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -50,12 +50,23 @@ public final class Dexter
   private boolean shouldExecuteOnSameThread = false;
   private boolean shouldForcePermission = false;
 
+  @Deprecated
   private Dexter(Activity activity) {
     initialize(activity);
   }
 
+  @Deprecated
   public static DexterBuilder.Permission withActivity(Activity activity) {
     return new Dexter(activity);
+  }
+
+
+  private Dexter(Context context) {
+    initialize(context);
+  }
+
+  public static DexterBuilder.Permission withContext(Context context) {
+    return new Dexter(context);
   }
 
   @Override public DexterBuilder.SinglePermissionListener withPermission(String permission) {

--- a/dexter/src/main/java/com/karumi/dexter/DexterBuilder.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterBuilder.java
@@ -25,6 +25,8 @@ public interface DexterBuilder {
 
   DexterBuilder onSameThread();
 
+  DexterBuilder force();
+
   DexterBuilder withErrorListener(PermissionRequestErrorListener errorListener);
 
   void check();

--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -235,7 +235,7 @@ final class DexterInstance {
     if (shouldShowRequestRationalePermissions.isEmpty()) {
       requestPermissionsToSystem(permissions);
     } else if (!rationaleAccepted.get()) {
-      PermissionRationaleToken permissionToken = new PermissionRationaleToken(this);
+      PermissionRationaleToken permissionToken = new PermissionRationaleToken(this, activity);
       listener.onPermissionRationaleShouldBeShown(shouldShowRequestRationalePermissions,
           permissionToken);
     }

--- a/dexter/src/main/java/com/karumi/dexter/PermissionRationaleToken.java
+++ b/dexter/src/main/java/com/karumi/dexter/PermissionRationaleToken.java
@@ -16,13 +16,17 @@
 
 package com.karumi.dexter;
 
+import android.content.Context;
+
 final class PermissionRationaleToken implements PermissionToken {
 
   private final DexterInstance dexterInstance;
   private boolean isTokenResolved = false;
+  private final Context context;
 
-  public PermissionRationaleToken(DexterInstance dexterInstance) {
+  public PermissionRationaleToken(DexterInstance dexterInstance, Context context) {
     this.dexterInstance = dexterInstance;
+    this.context = context;
   }
 
   @Override public void continuePermissionRequest() {
@@ -37,5 +41,9 @@ final class PermissionRationaleToken implements PermissionToken {
       dexterInstance.onCancelPermissionRequest();
       isTokenResolved = true;
     }
+  }
+
+  @Override public Context getContext() {
+    return context;
   }
 }

--- a/dexter/src/main/java/com/karumi/dexter/PermissionToken.java
+++ b/dexter/src/main/java/com/karumi/dexter/PermissionToken.java
@@ -16,6 +16,8 @@
 
 package com.karumi.dexter;
 
+import android.content.Context;
+
 /**
  * Utility class to let clients show the user how is the permission going to be used
  * Clients of this class must call one of the two methods and only once
@@ -31,4 +33,9 @@ public interface PermissionToken {
    * Cancels the permission request process
    */
   void cancelPermissionRequest();
+
+  /**
+   * @return Context associated with this token
+   */
+  Context getContext();
 }

--- a/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
+++ b/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
@@ -70,20 +70,21 @@ import static org.mockito.Mockito.when;
   }
 
   @Test(expected = DexterException.class) public void onNoPermissionCheckedThenThrowException() {
-    dexter.checkPermissions(multiplePermissionsListener, Collections.<String>emptyList(), THREAD);
+    dexter.checkPermissions(multiplePermissionsListener, Collections.<String>emptyList(), THREAD,
+                            false);
   }
 
   @Test(expected = DexterException.class)
   public void onCheckPermissionMoreThanOnceThenThrowException() {
     givenPermissionIsAlreadyDenied(ANY_PERMISSION);
-    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD);
-    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD);
+    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD, false);
+    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD, false);
   }
 
   @Test public void onPermissionAlreadyGrantedThenNotifiesListener() {
     givenPermissionIsAlreadyGranted(ANY_PERMISSION);
 
-    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD);
+    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD, false);
 
     thenPermissionIsGranted(ANY_PERMISSION);
   }
@@ -182,7 +183,7 @@ import static org.mockito.Mockito.when;
   }
 
   private void whenCheckPermission(PermissionListener permissionListener, String permission) {
-    dexter.checkPermission(permissionListener, permission, THREAD);
+    dexter.checkPermission(permissionListener, permission, THREAD, false);
     dexter.onActivityReady(activity);
   }
 
@@ -257,7 +258,7 @@ import static org.mockito.Mockito.when;
 
   private class CheckPermissionWithOnActivityReadyInBackground implements CheckPermissionAction {
     @Override public void check(final PermissionListener listener, final String permission) {
-      dexter.checkPermission(listener, permission, THREAD);
+      dexter.checkPermission(listener, permission, THREAD, false);
       asyncExecutor.execute(new Runnable() {
         @Override public void run() {
           dexter.onActivityReady(activity);

--- a/dexter/src/test/java/com/karumi/dexter/MultiplePermissionListenerThreadDecoratorTest.java
+++ b/dexter/src/test/java/com/karumi/dexter/MultiplePermissionListenerThreadDecoratorTest.java
@@ -16,14 +16,18 @@
 
 package com.karumi.dexter;
 
+import android.content.Context;
+
 import com.karumi.dexter.listener.PermissionRequest;
 import com.karumi.dexter.listener.multi.MultiplePermissionsListener;
-import java.util.List;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertTrue;
@@ -68,6 +72,10 @@ import static org.mockito.Mockito.verify;
 
     @Override public void cancelPermissionRequest() {
 
+    }
+
+    @Override public Context getContext() {
+      return null;
     }
   }
 

--- a/sample/src/main/java/com/karumi/dexter/sample/SampleActivity.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/SampleActivity.java
@@ -27,9 +27,7 @@ import android.support.design.widget.Snackbar;
 import android.support.v4.content.ContextCompat;
 import android.view.ViewGroup;
 import android.widget.TextView;
-import butterknife.Bind;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
+
 import com.karumi.dexter.Dexter;
 import com.karumi.dexter.PermissionToken;
 import com.karumi.dexter.listener.PermissionRequestErrorListener;
@@ -40,6 +38,10 @@ import com.karumi.dexter.listener.single.CompositePermissionListener;
 import com.karumi.dexter.listener.single.DialogOnDeniedPermissionListener;
 import com.karumi.dexter.listener.single.PermissionListener;
 import com.karumi.dexter.listener.single.SnackbarOnDeniedPermissionListener;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
 
 /**
  * Sample activity showing the permission request process with Dexter.
@@ -65,7 +67,7 @@ public class SampleActivity extends Activity {
   }
 
   @OnClick(R.id.all_permissions_button) public void onAllPermissionsButtonClicked() {
-    Dexter.withActivity(this)
+    Dexter.withContext(this)
         .withPermissions(Manifest.permission.CAMERA, Manifest.permission.READ_CONTACTS,
             Manifest.permission.RECORD_AUDIO)
         .withListener(allPermissionsListener)
@@ -76,7 +78,7 @@ public class SampleActivity extends Activity {
   @OnClick(R.id.camera_permission_button) public void onCameraPermissionButtonClicked() {
     new Thread(new Runnable() {
       @Override public void run() {
-        Dexter.withActivity(SampleActivity.this)
+        Dexter.withContext(SampleActivity.this)
             .withPermission(Manifest.permission.CAMERA)
             .withListener(cameraPermissionListener)
             .withErrorListener(errorListener)
@@ -87,7 +89,7 @@ public class SampleActivity extends Activity {
   }
 
   @OnClick(R.id.contacts_permission_button) public void onContactsPermissionButtonClicked() {
-    Dexter.withActivity(this)
+    Dexter.withContext(this)
         .withPermission(Manifest.permission.READ_CONTACTS)
         .withListener(contactsPermissionListener)
         .withErrorListener(errorListener)
@@ -95,7 +97,7 @@ public class SampleActivity extends Activity {
   }
 
   @OnClick(R.id.audio_permission_button) public void onAudioPermissionButtonClicked() {
-    Dexter.withActivity(this)
+    Dexter.withContext(this)
         .withPermission(Manifest.permission.RECORD_AUDIO)
         .withListener(audioPermissionListener)
         .withErrorListener(errorListener)
@@ -104,7 +106,9 @@ public class SampleActivity extends Activity {
 
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   public void showPermissionRationale(final PermissionToken token) {
-    new AlertDialog.Builder(this).setTitle(R.string.permission_rationale_title)
+    //Use the context of the token to display alert dialog. This is useful in an environment
+    // laking of activities.
+    new AlertDialog.Builder(token.getContext()).setTitle(R.string.permission_rationale_title)
         .setMessage(R.string.permission_rationale_message)
         .setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
           @Override public void onClick(DialogInterface dialog, int which) {


### PR DESCRIPTION
Hello,

In the last commit I have made some progress to use a Context instead of Activity. I had the need to use Dexter from a lib that has no activity and also from an Application class. It is working in these two uses cases. 

I have also added the activity used for asking permission request in PermissionToken object. User can use this context to display a dialog when `onPermissionRationaleShouldBeShown()` is called. 

I hope I have done things right for you to accept my push request. 

BR