### PR TITLE
Check permissions with PermissionChecker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.0'
+    classpath 'com.android.tools.build:gradle:2.3.1'
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.1'
+    classpath 'com.android.tools.build:gradle:2.3.3'
   }
 }
 

--- a/dexter/build.gradle
+++ b/dexter/build.gradle
@@ -24,9 +24,9 @@ android {
 }
 
 dependencies {
-  compile fileTree(include: ['*.jar'], dir: 'libs')
-  compile 'com.android.support:appcompat-v7:25.2.0'
-  compile 'com.android.support:design:25.2.0'
+  compile fileTree(dir: 'libs', include: ['*.jar'])
+  compile 'com.android.support:appcompat-v7:25.3.1'
+  compile 'com.android.support:design:25.3.1'
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.9.5'
 }

--- a/dexter/src/main/java/com/karumi/dexter/AndroidPermissionService.java
+++ b/dexter/src/main/java/com/karumi/dexter/AndroidPermissionService.java
@@ -21,7 +21,7 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.ActivityCompat;
-import android.support.v4.content.ContextCompat;
+import android.support.v4.content.PermissionChecker;
 
 /**
  * Wrapper class for all the static calls to the Android permission system
@@ -29,10 +29,10 @@ import android.support.v4.content.ContextCompat;
 class AndroidPermissionService {
 
   /**
-   * @see ContextCompat#checkSelfPermission
+   * @see PermissionChecker#checkSelfPermission
    */
   int checkSelfPermission(@NonNull Context context, @NonNull String permission) {
-    return ContextCompat.checkSelfPermission(context, permission);
+    return PermissionChecker.checkSelfPermission(context, permission);
   }
 
   /**

--- a/dexter/src/main/java/com/karumi/dexter/DexterActivity.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterActivity.java
@@ -18,14 +18,19 @@ package com.karumi.dexter;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.PermissionChecker;
 import android.view.WindowManager;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedList;
 
-public final class DexterActivity extends Activity implements ActivityCompat.OnRequestPermissionsResultCallback {
+public final class DexterActivity extends Activity
+    implements ActivityCompat.OnRequestPermissionsResultCallback {
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -48,15 +53,34 @@ public final class DexterActivity extends Activity implements ActivityCompat.OnR
     Collection<String> grantedPermissions = new LinkedList<>();
     Collection<String> deniedPermissions = new LinkedList<>();
 
-    for (int i = 0; i < permissions.length; i++) {
-      String permission = permissions[i];
-      if (grantResults[i] == PackageManager.PERMISSION_DENIED) {
-        deniedPermissions.add(permission);
-      } else {
-        grantedPermissions.add(permission);
+    if (isTargetSdkUnderAndroidM()) {
+      deniedPermissions.addAll(Arrays.asList(permissions));
+    } else {
+      for (int i = 0; i < permissions.length; i++) {
+        String permission = permissions[i];
+        switch (grantResults[i]) {
+          case PermissionChecker.PERMISSION_DENIED:
+          case PermissionChecker.PERMISSION_DENIED_APP_OP:
+            deniedPermissions.add(permission);
+            break;
+          case PermissionChecker.PERMISSION_GRANTED:
+            grantedPermissions.add(permission);
+            break;
+          default:
+        }
       }
     }
 
     Dexter.onPermissionsRequested(grantedPermissions, deniedPermissions);
+  }
+
+  private boolean isTargetSdkUnderAndroidM() {
+    try {
+      final PackageInfo info = getPackageManager().getPackageInfo(getPackageName(), 0);
+      int targetSdkVersion = info.applicationInfo.targetSdkVersion;
+      return targetSdkVersion < Build.VERSION_CODES.M;
+    } catch (PackageManager.NameNotFoundException ignored) {
+      return false;
+    }
   }
 }

--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -21,6 +21,7 @@ import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
+import android.support.v4.content.PermissionChecker;
 import com.karumi.dexter.listener.DexterError;
 import com.karumi.dexter.listener.PermissionDeniedResponse;
 import com.karumi.dexter.listener.PermissionGrantedResponse;
@@ -173,11 +174,13 @@ final class DexterInstance {
 
     for (String permission : pendingPermissions) {
       int permissionState = checkSelfPermission(activity, permission);
+
       switch (permissionState) {
-        case PackageManager.PERMISSION_DENIED:
+        case PermissionChecker.PERMISSION_DENIED:
+        case PermissionChecker.PERMISSION_DENIED_APP_OP:
           permissionStates.addDeniedPermission(permission);
           break;
-        case PackageManager.PERMISSION_GRANTED:
+        case PermissionChecker.PERMISSION_GRANTED:
         default:
           permissionStates.addGrantedPermission(permission);
           break;
@@ -327,7 +330,7 @@ final class DexterInstance {
   private boolean isEveryPermissionGranted(Collection<String> permissions, Context context) {
     for (String permission : permissions) {
       int permissionState = androidPermissionService.checkSelfPermission(context, permission);
-      if (permissionState != PackageManager.PERMISSION_GRANTED) {
+      if (permissionState != PermissionChecker.PERMISSION_GRANTED) {
         return false;
       }
     }

--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -115,6 +115,7 @@ final class DexterInstance {
 
     if (permissionStates != null) {
       handleDeniedPermissions(permissionStates.getDeniedPermissions());
+      updatePermissionsAsDenied(permissionStates.getImpossibleToGrantPermissions());
       updatePermissionsAsGranted(permissionStates.getGrantedPermissions());
     }
   }
@@ -176,8 +177,10 @@ final class DexterInstance {
       int permissionState = checkSelfPermission(activity, permission);
 
       switch (permissionState) {
-        case PermissionChecker.PERMISSION_DENIED:
         case PermissionChecker.PERMISSION_DENIED_APP_OP:
+          permissionStates.addImpossibleToGrantPermission(permission);
+          break;
+        case PermissionChecker.PERMISSION_DENIED:
           permissionStates.addDeniedPermission(permission);
           break;
         case PermissionChecker.PERMISSION_GRANTED:
@@ -339,10 +342,15 @@ final class DexterInstance {
 
   private final class PermissionStates {
     private final Collection<String> deniedPermissions = new LinkedList<>();
+    private final Collection<String> impossibleToGrantPermissions = new LinkedList<>();
     private final Collection<String> grantedPermissions = new LinkedList<>();
 
     private void addDeniedPermission(String permission) {
       deniedPermissions.add(permission);
+    }
+
+    private void addImpossibleToGrantPermission(String permission) {
+      impossibleToGrantPermissions.add(permission);
     }
 
     private void addGrantedPermission(String permission) {
@@ -355,6 +363,10 @@ final class DexterInstance {
 
     private Collection<String> getGrantedPermissions() {
       return grantedPermissions;
+    }
+
+    public Collection<String> getImpossibleToGrantPermissions() {
+      return impossibleToGrantPermissions;
     }
   }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -23,7 +23,7 @@ android {
 
 dependencies {
   compile fileTree(include: ['*.jar'], dir: 'libs')
-  compile 'com.android.support:appcompat-v7:25.2.0'
+  compile 'com.android.support:appcompat-v7:25.3.1'
   compile 'com.jakewharton:butterknife:8.6.0'
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.6.0'
   compile project(':dexter')


### PR DESCRIPTION
With this PR we are trying to address the issue described #140 where apps targeting SDKs lower than M are granted the permissions even though the user has rejected it through the OS settings. 
We are now using the newer `PermissionChecker` class and handling the permissions denied in a more graceful way.