### PR TITLE
Fix issue where Lopper.loop() is called even if a looper already exists

### DIFF
--- a/dexter/build.gradle
+++ b/dexter/build.gradle
@@ -11,6 +11,7 @@ android {
     versionCode 1
     versionName "1.0"
     consumerProguardFiles 'proguard-rules.pro'
+    testInstrumentationRunner "android.test.InstrumentationTestRunner"
   }
   buildTypes {
     debug {

--- a/dexter/src/main/java/com/karumi/dexter/DexterException.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterException.java
@@ -20,9 +20,9 @@ import com.karumi.dexter.listener.DexterError;
 
 final class DexterException extends IllegalStateException {
 
-  public final DexterError error;
+  final DexterError error;
 
-  public DexterException(String detailMessage, DexterError error) {
+  DexterException(String detailMessage, DexterError error) {
     super(detailMessage);
     this.error = error;
   }

--- a/dexter/src/main/java/com/karumi/dexter/MultiplePermissionsListenerToPermissionListenerAdapter.java
+++ b/dexter/src/main/java/com/karumi/dexter/MultiplePermissionsListenerToPermissionListenerAdapter.java
@@ -32,7 +32,7 @@ final class MultiplePermissionsListenerToPermissionListenerAdapter
 
   private final PermissionListener listener;
 
-  public MultiplePermissionsListenerToPermissionListenerAdapter(PermissionListener listener) {
+  MultiplePermissionsListenerToPermissionListenerAdapter(PermissionListener listener) {
     this.listener = listener;
   }
 

--- a/dexter/src/main/java/com/karumi/dexter/PermissionRationaleToken.java
+++ b/dexter/src/main/java/com/karumi/dexter/PermissionRationaleToken.java
@@ -21,7 +21,7 @@ final class PermissionRationaleToken implements PermissionToken {
   private final DexterInstance dexterInstance;
   private boolean isTokenResolved = false;
 
-  public PermissionRationaleToken(DexterInstance dexterInstance) {
+  PermissionRationaleToken(DexterInstance dexterInstance) {
     this.dexterInstance = dexterInstance;
   }
 

--- a/dexter/src/main/java/com/karumi/dexter/WorkerThread.java
+++ b/dexter/src/main/java/com/karumi/dexter/WorkerThread.java
@@ -25,9 +25,12 @@ import android.os.Looper;
 final class WorkerThread implements Thread {
 
   private final Handler handler;
+  private boolean wasLooperNull = false;
 
   WorkerThread() {
+    //Handle the case where the current thread has not called Lopper.prepare()
     if (Looper.myLooper() == null) {
+      wasLooperNull = true;
       Looper.prepare();
     }
     handler = new Handler();
@@ -38,6 +41,9 @@ final class WorkerThread implements Thread {
   }
 
   @Override public void loop() {
-    Looper.loop();
+    //Handle the case where there is an already existing Looper in the current thread.
+    if (wasLooperNull) {
+      Looper.loop();
+    }
   }
 }

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -9,6 +9,8 @@ android {
     targetSdkVersion 25
     versionCode 1
     versionName "1.0"
+
+    testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
   }
   buildTypes {
     debug {
@@ -27,4 +29,9 @@ dependencies {
   compile 'com.jakewharton:butterknife:8.6.0'
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.6.0'
   compile project(':dexter')
+  androidTestCompile 'com.android.support:support-annotations:25.2.0'
+  androidTestCompile 'com.android.support.test:runner:0.5'
+  androidTestCompile 'com.android.support.test:rules:0.5'
+  androidTestCompile 'org.awaitility:awaitility:3.0.0'
+  androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
 }

--- a/sample/src/androidTest/java/com/karumi/dexter/sample/DexterTest.java
+++ b/sample/src/androidTest/java/com/karumi/dexter/sample/DexterTest.java
@@ -1,0 +1,103 @@
+package com.karumi.dexter.sample;
+
+import android.Manifest;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.support.test.rule.ActivityTestRule;
+import android.support.test.runner.AndroidJUnit4;
+import android.util.Log;
+
+import com.karumi.dexter.Dexter;
+import com.karumi.dexter.listener.DexterError;
+import com.karumi.dexter.listener.PermissionDeniedResponse;
+import com.karumi.dexter.listener.PermissionGrantedResponse;
+import com.karumi.dexter.listener.PermissionRequestErrorListener;
+import com.karumi.dexter.listener.single.BasePermissionListener;
+import com.karumi.dexter.listener.single.PermissionListener;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(AndroidJUnit4.class)
+public class DexterTest {
+
+    private static final String TAG = "DexterTest";
+    private final AtomicBoolean unblock = new AtomicBoolean(false);
+    private final PermissionListener permissionListener = new BasePermissionListener() {
+        @Override
+        public void onPermissionGranted(PermissionGrantedResponse response) {
+            unblock();
+        }
+
+        @Override
+        public void onPermissionDenied(PermissionDeniedResponse response) {
+            unblock();
+        }
+    };
+    private final PermissionRequestErrorListener errorListener = new PermissionRequestErrorListener() {
+        @Override
+        public void onError(DexterError error) {
+            Log.i(TAG, error.toString());
+            unblock();
+        }
+    };
+    @Rule
+    public ActivityTestRule<SampleActivity> activityTestRule = new ActivityTestRule<>(SampleActivity.class);
+    private Handler handler;
+    private HandlerThread handlerThread;
+
+    @Before
+    public void setUp() throws Exception {
+        handlerThread = new HandlerThread(TAG);
+        handlerThread.start();
+        handler = new Handler(handlerThread.getLooper());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        handlerThread.quit();
+    }
+
+    @Test
+    public void testWithLooper() {
+        final AtomicBoolean milestone = new AtomicBoolean(false);
+        handler.post(new Runnable() {
+            @Override
+            public void run() {
+                getPermission(Manifest.permission.CAMERA);
+                Log.d(TAG, "Permission are asked");
+                milestone.set(true);
+            }
+        });
+        block();
+        assertThat(milestone.get(), is(true));
+    }
+
+    private void getPermission(String permission) {
+        Dexter.withActivity(activityTestRule.getActivity())
+            .withPermission(permission)
+            .withListener(permissionListener)
+            .withErrorListener(errorListener)
+            .onSameThread()
+            .check();
+    }
+
+    private void unblock() {
+        unblock.set(true);
+    }
+
+    private void block() {
+        await().atMost(10, TimeUnit.MINUTES).untilTrue(unblock);
+        unblock.set(false);
+    }
+}


### PR DESCRIPTION
I have run into a bug where execution flow blocked in `Lopper.loop()` called from Dexter, whereas I wanted that execution continue. Indeed, execution thread of Dexter was run from a handler. So a `Looper` already exists !

This is the reason of this commit.

