### PR TITLE
Add force permission option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,18 @@ Dexter.withActivity(activity)
 	.check();
 ```
 
+### Force
+For some reason, you may want to force permission asking even if Android system is 
+telling that permission is granted. 
+
+```java
+Dexter.withActivity(activity)
+	.withPermission(permission)
+	.withListener(listener)
+	.force()
+	.check();
+```
+
 ### Showing a rationale
 Android will notify you when you are requesting a permission that needs an additional explanation for its usage, either because it is considered dangerous, or because the user has already declined that permission once.
 

--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -48,6 +48,7 @@ public final class Dexter
   private MultiplePermissionsListener listener = new BaseMultiplePermissionsListener();
   private PermissionRequestErrorListener errorListener = new EmptyPermissionRequestErrorListener();
   private boolean shouldExecuteOnSameThread = false;
+  private boolean shouldForcePermission = false;
 
   private Dexter(Activity activity) {
     initialize(activity);
@@ -88,6 +89,11 @@ public final class Dexter
     return this;
   }
 
+  @Override public DexterBuilder force() {
+    shouldForcePermission = true;
+    return this;
+  }
+
   @Override public DexterBuilder withErrorListener(PermissionRequestErrorListener errorListener) {
     this.errorListener = errorListener;
     return this;
@@ -96,7 +102,7 @@ public final class Dexter
   @Override public void check() {
     try {
       Thread thread = getThread();
-      instance.checkPermissions(listener, permissions, thread);
+      instance.checkPermissions(listener, permissions, thread, shouldForcePermission);
     } catch (DexterException e) {
       errorListener.onError(e.error);
     }

--- a/dexter/src/main/java/com/karumi/dexter/DexterBuilder.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterBuilder.java
@@ -25,6 +25,8 @@ public interface DexterBuilder {
 
   DexterBuilder onSameThread();
 
+  DexterBuilder force();
+
   DexterBuilder withErrorListener(PermissionRequestErrorListener errorListener);
 
   void check();

--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -57,6 +57,7 @@ final class DexterInstance {
 
   private Activity activity;
   private MultiplePermissionsListener listener = EMPTY_LISTENER;
+  private boolean forcePermissionRequest = false;
 
   DexterInstance(Context context, AndroidPermissionService androidPermissionService,
       IntentProvider intentProvider) {
@@ -81,8 +82,9 @@ final class DexterInstance {
    * @param permission One of the values found in {@link android.Manifest.permission}
    * @param thread thread the Listener methods will be called on
    */
-  void checkPermission(PermissionListener listener, String permission, Thread thread) {
-    checkSinglePermission(listener, permission, thread);
+  void checkPermission(PermissionListener listener, String permission, Thread thread,
+                       boolean shouldForcePermission) {
+    checkSinglePermission(listener, permission, thread, shouldForcePermission);
   }
 
   /**
@@ -94,8 +96,8 @@ final class DexterInstance {
    * @param thread thread the Listener methods will be called on
    */
   void checkPermissions(MultiplePermissionsListener listener, Collection<String> permissions,
-      Thread thread) {
-    checkMultiplePermissions(listener, permissions, thread);
+      Thread thread, boolean shouldForcePermission) {
+    checkMultiplePermissions(listener, permissions, thread, shouldForcePermission);
   }
 
   /**
@@ -194,6 +196,14 @@ final class DexterInstance {
    * https://github.com/Karumi/Dexter/issues/86
    */
   private int checkSelfPermission(Activity activity, String permission) {
+    // If we want to force permission, return Permission denied here, so that permission is asked later. Otherwise,
+    // system may answer PERMISSION_GRANTED and we will not ask for permission explicitly.
+    // This is working because this method is only called by
+    // DexterInstance.onActivityReady() -> DexterInstance.getPermissionStates(), and then all PERMISSION_DENIED tied
+    // with a permission string are handled in asking for permission explicitly.
+    if (forcePermissionRequest) {
+      return PackageManager.PERMISSION_DENIED;
+    }
     try {
       return androidPermissionService.checkSelfPermission(activity, permission);
     } catch (RuntimeException ignored) {
@@ -288,14 +298,14 @@ final class DexterInstance {
   }
 
   private void checkSinglePermission(PermissionListener listener, String permission,
-      Thread thread) {
+      Thread thread, boolean shouldForcePermission) {
     MultiplePermissionsListener adapter =
         new MultiplePermissionsListenerToPermissionListenerAdapter(listener);
-    checkMultiplePermissions(adapter, Collections.singleton(permission), thread);
+    checkMultiplePermissions(adapter, Collections.singleton(permission), thread, shouldForcePermission);
   }
 
   private void checkMultiplePermissions(final MultiplePermissionsListener listener,
-      final Collection<String> permissions, Thread thread) {
+      final Collection<String> permissions, Thread thread, boolean shouldForcePermission) {
     checkNoDexterRequestOngoing();
     checkRequestSomePermission(permissions);
 
@@ -303,11 +313,12 @@ final class DexterInstance {
       return;
     }
 
+    forcePermissionRequest = shouldForcePermission;
     pendingPermissions.clear();
     pendingPermissions.addAll(permissions);
     multiplePermissionsReport.clear();
     this.listener = new MultiplePermissionListenerThreadDecorator(listener, thread);
-    if (isEveryPermissionGranted(permissions, context.get())) {
+    if (isEveryPermissionGranted(permissions, context.get()) && !shouldForcePermission) {
       thread.execute(new Runnable() {
         @Override public void run() {
           MultiplePermissionsReport report = new MultiplePermissionsReport();

--- a/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
+++ b/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
@@ -70,20 +70,21 @@ import static org.mockito.Mockito.when;
   }
 
   @Test(expected = DexterException.class) public void onNoPermissionCheckedThenThrowException() {
-    dexter.checkPermissions(multiplePermissionsListener, Collections.<String>emptyList(), THREAD);
+    dexter.checkPermissions(multiplePermissionsListener, Collections.<String>emptyList(), THREAD,
+                            false);
   }
 
   @Test(expected = DexterException.class)
   public void onCheckPermissionMoreThanOnceThenThrowException() {
     givenPermissionIsAlreadyDenied(ANY_PERMISSION);
-    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD);
-    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD);
+    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD, false);
+    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD, false);
   }
 
   @Test public void onPermissionAlreadyGrantedThenNotifiesListener() {
     givenPermissionIsAlreadyGranted(ANY_PERMISSION);
 
-    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD);
+    dexter.checkPermission(permissionListener, ANY_PERMISSION, THREAD, false);
 
     thenPermissionIsGranted(ANY_PERMISSION);
   }
@@ -182,7 +183,7 @@ import static org.mockito.Mockito.when;
   }
 
   private void whenCheckPermission(PermissionListener permissionListener, String permission) {
-    dexter.checkPermission(permissionListener, permission, THREAD);
+    dexter.checkPermission(permissionListener, permission, THREAD, false);
     dexter.onActivityReady(activity);
   }
 
@@ -257,7 +258,7 @@ import static org.mockito.Mockito.when;
 
   private class CheckPermissionWithOnActivityReadyInBackground implements CheckPermissionAction {
     @Override public void check(final PermissionListener listener, final String permission) {
-      dexter.checkPermission(listener, permission, THREAD);
+      dexter.checkPermission(listener, permission, THREAD, false);
       asyncExecutor.execute(new Runnable() {
         @Override public void run() {
           dexter.onActivityReady(activity);


### PR DESCRIPTION
Hi

I have added a "force" option to ask for permission even if the system tells that the permission is granted.

I have the need of this option because I am developing a system app. On my particular device, Android is telling me that I got the permission whereas I still need to ask for explicitly. I am not sure that this problem occurs on all devices.

I have already made a request of this change here : https://github.com/Karumi/Dexter/pull/147 

I have reworked it to separate several changes I have made.

Nevertheless, I would need some help to write some test about it. I would appreciate some hint for me to write like you've done before to test your library. We might want to test the case where the system is telling that permission is granted and still we are asking for permission. Or a more abstract test where we are asking for permission in any cases. 

Thank you very much for spending some times in reviewing my code. 