### PR TITLE
[DEBUG] Notify client that permission process has ended

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterActivity.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterActivity.java
@@ -20,6 +20,7 @@ import android.app.Activity;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.v4.app.ActivityCompat;
 import android.view.WindowManager;
 import java.util.Collection;
@@ -43,8 +44,9 @@ public final class DexterActivity extends Activity implements ActivityCompat.OnR
     Dexter.onActivityReady(this);
   }
 
-  @Override public void onRequestPermissionsResult(int requestCode, String[] permissions,
-      int[] grantResults) {
+  @Override public void onRequestPermissionsResult(int requestCode,
+                                                   @NonNull String[] permissions,
+                                                   @NonNull int[] grantResults) {
     Collection<String> grantedPermissions = new LinkedList<>();
     Collection<String> deniedPermissions = new LinkedList<>();
 

--- a/dexter/src/main/java/com/karumi/dexter/DexterException.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterException.java
@@ -20,9 +20,9 @@ import com.karumi.dexter.listener.DexterError;
 
 final class DexterException extends IllegalStateException {
 
-  public final DexterError error;
+  final DexterError error;
 
-  public DexterException(String detailMessage, DexterError error) {
+  DexterException(String detailMessage, DexterError error) {
     super(detailMessage);
     this.error = error;
   }

--- a/dexter/src/main/java/com/karumi/dexter/MultiplePermissionsListenerToPermissionListenerAdapter.java
+++ b/dexter/src/main/java/com/karumi/dexter/MultiplePermissionsListenerToPermissionListenerAdapter.java
@@ -32,7 +32,7 @@ final class MultiplePermissionsListenerToPermissionListenerAdapter
 
   private final PermissionListener listener;
 
-  public MultiplePermissionsListenerToPermissionListenerAdapter(PermissionListener listener) {
+  MultiplePermissionsListenerToPermissionListenerAdapter(PermissionListener listener) {
     this.listener = listener;
   }
 

--- a/dexter/src/main/java/com/karumi/dexter/PermissionRationaleToken.java
+++ b/dexter/src/main/java/com/karumi/dexter/PermissionRationaleToken.java
@@ -21,7 +21,7 @@ final class PermissionRationaleToken implements PermissionToken {
   private final DexterInstance dexterInstance;
   private boolean isTokenResolved = false;
 
-  public PermissionRationaleToken(DexterInstance dexterInstance) {
+  PermissionRationaleToken(DexterInstance dexterInstance) {
     this.dexterInstance = dexterInstance;
   }
 


### PR DESCRIPTION
Hi,

I have noticed that if DexterActivity is launched when screen is off, `DexterActivity.onRequestPermissionsResult()` is never called. Thus client is never notified that permission process has ended. 

I have implemented a simple mechanism to detect that `DexterActivity.onRequestPermissionsResult()` is called before `DexterActivity.onDestroy()`. If it not the case, then we simulate a permission request cancel.

Regards,

B. 