### PR TITLE
Remove single instance attribute in AndroidManifest for the ghost activity

### DIFF
--- a/dexter/src/main/AndroidManifest.xml
+++ b/dexter/src/main/AndroidManifest.xml
@@ -22,7 +22,6 @@
     <activity
         android:name=".DexterActivity"
         android:theme="@style/Dexter.Internal.Theme.Transparent"
-        android:launchMode="singleInstance"
         />
   </application>
 


### PR DESCRIPTION
This PR applies the suggested changes in #143 

@nex0s, @ultraon, @EmmettWilson can you see if this change addresses the issue you were having?

The rationale behind the original setup was to stop worrying about creating more than one _inner activity_ (or _ghost activity_) which is what Dexter uses behind the scenes to ask for permissions. I've been doing some testing myself and looks like there is no way of creating multiple inner activities anymore (I've been rotating the device in every single step, pressed the back button and so), what's more, if a new activity is created then Dexter will replace its reference to point the new one and the old one should be flagged to be removed.

Let me know if you can find any problem with this solution.