### PR TITLE
Update Gradle build to target SDK 26 in reference to issue #177

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
   repositories {
     jcenter()
+    google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.3'
+    classpath 'com.android.tools.build:gradle:3.0.0-beta7'
   }
 }
 
@@ -11,6 +12,7 @@ allprojects {
   repositories {
     jcenter()
     mavenCentral()
+    google()
     maven { url 'https://maven.google.com' }
   }
 

--- a/dexter/build.gradle
+++ b/dexter/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion '25.0.0'
+  compileSdkVersion 26
+  buildToolsVersion '26.0.2'
 
   defaultConfig {
-    minSdkVersion 10
-    targetSdkVersion 25
+    minSdkVersion 15
+    targetSdkVersion 26
     versionCode 1
     versionName "1.0"
     consumerProguardFiles 'proguard-rules.pro'
@@ -26,8 +26,8 @@ android {
 
 dependencies {
   compile fileTree(dir: 'libs', include: ['*.jar'])
-  compile 'com.android.support:appcompat-v7:25.3.1'
-  compile 'com.android.support:design:25.3.1'
+  compile 'com.android.support:appcompat-v7:26.1.0'
+  compile 'com.android.support:design:26.1.0'
   testCompile 'junit:junit:4.12'
   testCompile 'org.mockito:mockito-core:1.9.5'
 }

--- a/dexter/build.gradle
+++ b/dexter/build.gradle
@@ -6,7 +6,7 @@ android {
   buildToolsVersion '26.0.2'
 
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 14
     targetSdkVersion 26
     versionCode 1
     versionName "1.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 06 10:14:11 CET 2017
+#Sat Oct 07 15:00:51 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -7,12 +7,12 @@ configurations.all {
 }
 
 android {
-  compileSdkVersion 25
-  buildToolsVersion '25.0.0'
+  compileSdkVersion 26
+  buildToolsVersion '26.0.2'
   defaultConfig {
     applicationId "com.karumi.dexter.sample"
     minSdkVersion 18
-    targetSdkVersion 25
+    targetSdkVersion 26
     versionCode 1
     versionName "1.0"
 
@@ -31,13 +31,13 @@ android {
 
 dependencies {
   compile fileTree(include: ['*.jar'], dir: 'libs')
-  compile 'com.android.support:appcompat-v7:25.3.1'
+  compile 'com.android.support:appcompat-v7:26.1.0'
   compile 'com.jakewharton:butterknife:8.6.0'
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.6.0'
   compile project(':dexter')
-  androidTestCompile 'com.android.support.test:runner:0.5'
-  androidTestCompile 'com.android.support.test:rules:0.5'
+  androidTestCompile 'com.android.support.test:runner:1.0.1'
+  androidTestCompile 'com.android.support.test:rules:1.0.1'
   androidTestCompile 'org.awaitility:awaitility:3.0.0'
   androidTestCompile 'org.hamcrest:hamcrest-library:1.3'
-  androidTestCompile 'com.android.support.test:rules:1.0.0'
+  androidTestCompile 'com.android.support.test:rules:1.0.1'
 }


### PR DESCRIPTION
Build test was successful, unfortunately the minSdkVersion in the core `dexter` module had to be raised to `14` from `10` to be compatible with newer versions of Gradle, but the impact should be minimal.