### PR TITLE
Update Readme latest gradle dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Include the library in your ``build.gradle``
 
 ```groovy
 dependencies{
-    compile 'com.karumi:dexter:4.2.0'
+    implementation 'com.karumi:dexter:4.2.0'
 }
 ```
 


### PR DESCRIPTION
As new gradle versions use `implementation` instead of `compile` i've changed it on the Readme