### PR TITLE
Fix token bypassed in base listeners

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/listener/multi/BaseMultiplePermissionsListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/multi/BaseMultiplePermissionsListener.java
@@ -33,6 +33,6 @@ public class BaseMultiplePermissionsListener implements MultiplePermissionsListe
 
   @Override public void onPermissionRationaleShouldBeShown(List<PermissionRequest> permissions,
       PermissionToken token) {
-    token.continuePermissionRequest();
+
   }
 }

--- a/dexter/src/main/java/com/karumi/dexter/listener/single/BasePermissionListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/single/BasePermissionListener.java
@@ -37,6 +37,6 @@ public class BasePermissionListener implements PermissionListener {
 
   @Override public void onPermissionRationaleShouldBeShown(PermissionRequest permission,
       PermissionToken token) {
-    token.continuePermissionRequest();
+
   }
 }


### PR DESCRIPTION
### What's in this PR?
- Fixes Karumi#184
  - Permission token control now only depends on `onPermissionRationaleShouldBeShown` function in `PermissionListener` / `MultiplePermissionsListener`