### PR TITLE
Fix request permission again after activity destroyed

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -124,7 +124,10 @@ final class DexterInstance {
    * Method called whenever the inner activity has been destroyed.
    */
   void onActivityDestroyed() {
+    activity = null;
     isRequestingPermission.set(false);
+    rationaleAccepted.set(false);
+    isShowingNativeDialog.set(false);
     listener = EMPTY_LISTENER;
   }
 


### PR DESCRIPTION
This pull request resolves following issue.

1. request permission once by calling `Dexter.check()`
2. remove the app from "recent task list" while system permission dialog is shown
3. relaunch the app from launcher and call same `Dexter.check()` again

DexterActivity won't request permission at step.3