### PR TITLE
Exclude android.support group from butterknife

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -33,7 +33,9 @@ dependencies {
   implementation fileTree(include: ['*.jar'], dir: 'libs')
   implementation 'com.android.support:appcompat-v7:27.1.1'
   implementation 'com.android.support:design:27.1.1'
-  implementation 'com.jakewharton:butterknife:8.6.0'
+  implementation 'com.jakewharton:butterknife:8.6.0',{
+    exclude group: 'com.android.support'
+  }
   implementation 'com.squareup.leakcanary:leakcanary-android:1.5.4'
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.6.0'
   implementation project(':dexter')


### PR DESCRIPTION
The sample project was giving a support compat error on the gradle file.

I've just excluded the support compat group from the butterknife library to fix it.