### PR TITLE
 Fix a bug caused by "singleTask"

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -125,6 +125,8 @@ final class DexterInstance {
    */
   void onActivityDestroyed() {
     isRequestingPermission.set(false);
+    isShowingNativeDialog.set(false);
+    rationaleAccepted.set(false);
     listener = EMPTY_LISTENER;
   }
 


### PR DESCRIPTION
if your activity is singleTask and you clicked "home" in this page ,you con't find permission box next time
 1. I clicked the home button in request permission page (DexterActivity)
 2. I clicked my app (I have a InitializeActivity  and it is singleTask ,so DexterActivity is destroy)
 3. I request permission again ,but i con't see the "Permission box".
   No matter what, it’s always right set  "rationaleAccepted and isShowingNativeDialog == false" .