### PR TITLE
Manually clean up DexterInstance when DexterActivity is finishing

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -124,11 +124,13 @@ final class DexterInstance {
    * Method called whenever the inner activity has been destroyed.
    */
   void onActivityDestroyed() {
-    activity = null;
-    isRequestingPermission.set(false);
-    rationaleAccepted.set(false);
-    isShowingNativeDialog.set(false);
-    listener = EMPTY_LISTENER;
+    if (activity != null) {
+      activity = null;
+      isRequestingPermission.set(false);
+      rationaleAccepted.set(false);
+      isShowingNativeDialog.set(false);
+      listener = EMPTY_LISTENER;
+    }
   }
 
   /**
@@ -275,7 +277,6 @@ final class DexterInstance {
         // the permission is checked. Issues #243 and #221
         if (activity != null) {
           activity.finish();
-          activity = null;
         }
         isRequestingPermission.set(false);
         rationaleAccepted.set(false);
@@ -315,6 +316,10 @@ final class DexterInstance {
 
     if (context.get() == null) {
       return;
+    }
+
+    if (activity != null && activity.isFinishing()) {
+      onActivityDestroyed();
     }
 
     pendingPermissions.clear();


### PR DESCRIPTION
### :pushpin: References
* **Issue:** 
   #### Steps to reproduce ####
   Launch two activities consecutively, with each activity asking for any new permission(s) in `onCreate`
 
   #### Bug ####
   Callback for second activity's permission request will not be called sometimes

   #### Issue ####
   After the second activity sets up the `DexterInstance` with new callback, `DexterActivity` fired from the first activity permission request calls `onDestroy` and wipes the callback.

### :tophat: What is the goal?

   Make state clean up synchronous.

### :memo: How is it being implemented?

    

Manually clean up the state by calling `onActivityDestroyed` when there already is a `DexterActivity` that is finishing up. Then, when `DexterActivity` calls `onDestroyed`, no cleaning is needed.

### :robot: How can it be tested?

Since testing this requires mocking activity life cycle events. Suggestions are welcome.
