### PR TITLE
Dexter.withContext(...) method so Dexter can be created using generic Context 

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -53,6 +53,12 @@ public final class Dexter
     initialize(context);
   }
 
+  /**
+   * Obsolete method requiring an {@link Activity} to start using Dexter.
+   *
+   * @deprecated Use {@link Dexter#withContext(Context)} instead.
+   */
+  @Deprecated
   public static DexterBuilder.Permission withActivity(Activity activity) {
     return new Dexter(activity);
   }

--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -49,12 +49,16 @@ public final class Dexter
   private PermissionRequestErrorListener errorListener = new EmptyPermissionRequestErrorListener();
   private boolean shouldExecuteOnSameThread = false;
 
-  private Dexter(Activity activity) {
-    initialize(activity);
+  private Dexter(Context context) {
+    initialize(context);
   }
 
   public static DexterBuilder.Permission withActivity(Activity activity) {
     return new Dexter(activity);
+  }
+
+  public static DexterBuilder.Permission withContext(Context context) {
+    return new Dexter(context);
   }
 
   @Override public DexterBuilder.SinglePermissionListener withPermission(String permission) {

--- a/sample/src/androidTest/java/com/karumi/dexter/sample/DexterTest.java
+++ b/sample/src/androidTest/java/com/karumi/dexter/sample/DexterTest.java
@@ -9,6 +9,7 @@ import androidx.test.rule.ActivityTestRule;
 import androidx.test.rule.GrantPermissionRule;
 
 import com.karumi.dexter.Dexter;
+import com.karumi.dexter.DexterBuilder;
 import com.karumi.dexter.listener.DexterError;
 import com.karumi.dexter.listener.PermissionDeniedResponse;
 import com.karumi.dexter.listener.PermissionGrantedResponse;
@@ -69,14 +70,27 @@ public class DexterTest {
   @Test public void testWithLooper() {
     AtomicBoolean milestone = new AtomicBoolean(false);
 
-    requestAndAcceptPermissionOnHandlerThread(milestone, Manifest.permission.CAMERA);
+    requestAndAcceptPermissionOnHandlerThread(milestone, Manifest.permission.CAMERA, false);
 
     block();
     assertThat(milestone.get(), is(true));
   }
 
-  private void getPermission(String permission) {
-    Dexter.withActivity(activityTestRule.getActivity())
+  @Test public void testWithLooperAndAppContext() {
+    AtomicBoolean milestone = new AtomicBoolean(false);
+
+    requestAndAcceptPermissionOnHandlerThread(milestone, Manifest.permission.CAMERA, true);
+
+    block();
+    assertThat(milestone.get(), is(true));
+  }
+
+  private void getPermission(String permission, boolean useAppContext) {
+    DexterBuilder.Permission dexter;
+    if (useAppContext) dexter = Dexter.withContext(activityTestRule.getActivity().getApplicationContext());
+    else dexter = Dexter.withActivity(activityTestRule.getActivity());
+
+    dexter
         .withPermission(permission)
         .withListener(permissionListener)
         .withErrorListener(errorListener)
@@ -85,10 +99,10 @@ public class DexterTest {
   }
 
   private void requestAndAcceptPermissionOnHandlerThread(final AtomicBoolean milestone,
-      final String permission) {
+      final String permission, boolean useAppContext) {
     handler.post(new Runnable() {
       @Override public void run() {
-        getPermission(permission);
+        getPermission(permission, useAppContext);
         milestone.set(true);
       }
     });

--- a/sample/src/main/java/com/karumi/dexter/sample/SampleActivity.java
+++ b/sample/src/main/java/com/karumi/dexter/sample/SampleActivity.java
@@ -65,7 +65,7 @@ public class SampleActivity extends Activity {
   }
 
   @OnClick(R.id.all_permissions_button) public void onAllPermissionsButtonClicked() {
-    Dexter.withActivity(this)
+    Dexter.withContext(getApplicationContext())
         .withPermissions(Manifest.permission.CAMERA, Manifest.permission.READ_CONTACTS,
             Manifest.permission.RECORD_AUDIO)
         .withListener(allPermissionsListener)
@@ -76,7 +76,7 @@ public class SampleActivity extends Activity {
   @OnClick(R.id.camera_permission_button) public void onCameraPermissionButtonClicked() {
     new Thread(new Runnable() {
       @Override public void run() {
-        Dexter.withActivity(SampleActivity.this)
+        Dexter.withContext(getApplicationContext())
             .withPermission(Manifest.permission.CAMERA)
             .withListener(cameraPermissionListener)
             .withErrorListener(errorListener)
@@ -87,7 +87,7 @@ public class SampleActivity extends Activity {
   }
 
   @OnClick(R.id.contacts_permission_button) public void onContactsPermissionButtonClicked() {
-    Dexter.withActivity(this)
+    Dexter.withContext(getApplicationContext())
         .withPermission(Manifest.permission.READ_CONTACTS)
         .withListener(contactsPermissionListener)
         .withErrorListener(errorListener)
@@ -95,7 +95,7 @@ public class SampleActivity extends Activity {
   }
 
   @OnClick(R.id.audio_permission_button) public void onAudioPermissionButtonClicked() {
-    Dexter.withActivity(this)
+    Dexter.withContext(getApplicationContext())
         .withPermission(Manifest.permission.RECORD_AUDIO)
         .withListener(audioPermissionListener)
         .withErrorListener(errorListener)


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Closes https://github.com/Karumi/Dexter/issues/167

### :tophat: What is the goal?

Allow to use generic context without the need to hold reference to an activity

### :memo: How is it being implemented?
Added additional method Dexter.withContext(Context context). Method Dexter.withActivity(...) is retained for backwards compatibility.

### :robot: How can it be tested?
I added test named testWithLooperAndAppContext to DexterTest. It uses application context to run the same scenario as testWithLooper

