### PR TITLE
Fix broadcast receiver support

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -17,7 +17,6 @@
 package com.karumi.dexter;
 
 import android.app.Activity;
-import android.app.Application;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -220,7 +219,7 @@ final class DexterInstance {
     }
 
     Intent intent = intentProvider.get(context, DexterActivity.class);
-    if (context instanceof Application) {
+    if (!(context instanceof Activity)) {
       intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
     }
     context.startActivity(intent);


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Fixes #255 

### :tophat: What is the goal?

Do not crash if the context used to start dexter is the one assigned to a broadcast receiver.

### :memo: How is it being implemented?

We've just changed a Dexter inner check in order to get this working.

### :robot: How can it be tested?

Current code coverage ensures already implemented scenarios are working properly. I'm not adding any automated test to ensure the context from a receiver is working because the effort is not worth it.
