### PR TITLE
Snackbar on permanently denied permission Listener

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/listener/SettingsClickListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/SettingsClickListener.java
@@ -1,0 +1,19 @@
+package com.karumi.dexter.listener;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.provider.Settings;
+import android.view.View;
+
+public class SettingsClickListener implements View.OnClickListener {
+    @Override
+    public void onClick(View view) {
+        Context context = view.getContext();
+        Intent myAppSettings = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+                Uri.parse("package:" + context.getPackageName()));
+        myAppSettings.addCategory(Intent.CATEGORY_DEFAULT);
+        myAppSettings.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        context.startActivity(myAppSettings);
+    }
+}

--- a/dexter/src/main/java/com/karumi/dexter/listener/SnackbarUtils.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/SnackbarUtils.java
@@ -1,0 +1,22 @@
+package com.karumi.dexter.listener;
+
+import android.view.View;
+
+import com.google.android.material.snackbar.BaseTransientBottomBar;
+import com.google.android.material.snackbar.Snackbar;
+
+public class SnackbarUtils {
+
+    public static void show(View view, String text, int duration, String buttonText,
+            View.OnClickListener onButtonClickListener,
+            BaseTransientBottomBar.BaseCallback<Snackbar> snackbarCallback) {
+        Snackbar snackbar = Snackbar.make(view, text, duration);
+        if (buttonText != null && onButtonClickListener != null) {
+            snackbar.setAction(buttonText, onButtonClickListener);
+        }
+        if (snackbarCallback != null) {
+            snackbar.addCallback(snackbarCallback);
+        }
+        snackbar.show();
+    }
+}

--- a/dexter/src/main/java/com/karumi/dexter/listener/multi/SnackbarOnAnyDeniedMultiplePermissionsListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/multi/SnackbarOnAnyDeniedMultiplePermissionsListener.java
@@ -16,14 +16,13 @@
 
 package com.karumi.dexter.listener.multi;
 
-import android.content.Context;
-import android.content.Intent;
-import android.net.Uri;
-import android.provider.Settings;
-import androidx.annotation.StringRes;
-import com.google.android.material.snackbar.Snackbar;
 import android.view.View;
+
+import com.google.android.material.snackbar.Snackbar;
 import com.karumi.dexter.MultiplePermissionsReport;
+import com.karumi.dexter.listener.SettingsClickListener;
+
+import androidx.annotation.StringRes;
 
 /**
  * Utility listener that shows a {@link Snackbar} with a custom text whenever a permission has been
@@ -122,16 +121,7 @@ public class SnackbarOnAnyDeniedMultiplePermissionsListener
      */
     public Builder withOpenSettingsButton(String buttonText) {
       this.buttonText = buttonText;
-      this.onClickListener = new View.OnClickListener() {
-        @Override public void onClick(View v) {
-          Context context = view.getContext();
-          Intent myAppSettings = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-              Uri.parse("package:" + context.getPackageName()));
-          myAppSettings.addCategory(Intent.CATEGORY_DEFAULT);
-          myAppSettings.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-          context.startActivity(myAppSettings);
-        }
-      };
+      this.onClickListener = new SettingsClickListener();
       return this;
     }
 

--- a/dexter/src/main/java/com/karumi/dexter/listener/multi/SnackbarOnAnyDeniedMultiplePermissionsListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/multi/SnackbarOnAnyDeniedMultiplePermissionsListener.java
@@ -21,6 +21,7 @@ import android.view.View;
 import com.google.android.material.snackbar.Snackbar;
 import com.karumi.dexter.MultiplePermissionsReport;
 import com.karumi.dexter.listener.SettingsClickListener;
+import com.karumi.dexter.listener.SnackbarUtils;
 
 import androidx.annotation.StringRes;
 
@@ -59,19 +60,8 @@ public class SnackbarOnAnyDeniedMultiplePermissionsListener
     super.onPermissionsChecked(report);
 
     if (!report.areAllPermissionsGranted()) {
-      showSnackbar();
+      SnackbarUtils.show(view, text, duration, buttonText, onButtonClickListener, snackbarCallback);
     }
-  }
-
-  private void showSnackbar() {
-    Snackbar snackbar = Snackbar.make(view, text, duration);
-    if (buttonText != null && onButtonClickListener != null) {
-      snackbar.setAction(buttonText, onButtonClickListener);
-    }
-    if (snackbarCallback != null) {
-      snackbar.addCallback(snackbarCallback);
-    }
-    snackbar.show();
   }
 
   /**

--- a/dexter/src/main/java/com/karumi/dexter/listener/multi/SnackbarOnAnyPermanentlyDeniedMultiplePermissionsListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/multi/SnackbarOnAnyPermanentlyDeniedMultiplePermissionsListener.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2015 Karumi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.karumi.dexter.listener.multi;
+
+import android.view.View;
+
+import com.google.android.material.snackbar.Snackbar;
+import com.karumi.dexter.MultiplePermissionsReport;
+import com.karumi.dexter.listener.SettingsClickListener;
+import com.karumi.dexter.listener.SnackbarUtils;
+
+import androidx.annotation.StringRes;
+
+/**
+ * Utility listener that shows a {@link Snackbar} with a custom text whenever a permission has been
+ * permanently denied
+ */
+public class SnackbarOnAnyPermanentlyDeniedMultiplePermissionsListener
+    extends BaseMultiplePermissionsListener {
+
+  private final View view;
+  private final String text;
+  private final String buttonText;
+  private final View.OnClickListener onButtonClickListener;
+  private final Snackbar.Callback snackbarCallback;
+  private final int duration;
+
+  /**
+   * @param view The view to find a parent from
+   * @param text Message displayed in the snackbar
+   * @param buttonText Message displayed in the snackbar button
+   * @param onButtonClickListener Action performed when the user clicks the snackbar button
+   */
+  private SnackbarOnAnyPermanentlyDeniedMultiplePermissionsListener(View view, String text,
+      String buttonText, View.OnClickListener onButtonClickListener,
+      Snackbar.Callback snackbarCallback, int duration) {
+    this.view = view;
+    this.text = text;
+    this.buttonText = buttonText;
+    this.onButtonClickListener = onButtonClickListener;
+    this.snackbarCallback = snackbarCallback;
+    this.duration = duration;
+  }
+
+  @Override public void onPermissionsChecked(MultiplePermissionsReport report) {
+    super.onPermissionsChecked(report);
+
+    if (!report.isAnyPermissionPermanentlyDenied()) {
+      SnackbarUtils.show(view, text, duration, buttonText, onButtonClickListener, snackbarCallback);
+    }
+  }
+
+  /**
+   * Builder class to configure the displayed snackbar
+   * Non set fields will not be shown
+   */
+  public static class Builder {
+    private final View view;
+    private final String text;
+    private String buttonText;
+    private View.OnClickListener onClickListener;
+    private Snackbar.Callback snackbarCallback;
+    private int duration = Snackbar.LENGTH_LONG;
+
+    private Builder(View view, String text) {
+      this.view = view;
+      this.text = text;
+    }
+
+    public static Builder with(View view, String text) {
+      return new Builder(view, text);
+    }
+
+    public static Builder with(View view, @StringRes int textResourceId) {
+      return Builder.with(view, view.getContext().getString(textResourceId));
+    }
+
+    /**
+     * Adds a text button with the provided click listener
+     */
+    public Builder withButton(String buttonText, View.OnClickListener onClickListener) {
+      this.buttonText = buttonText;
+      this.onClickListener = onClickListener;
+      return this;
+    }
+
+    /**
+     * Adds a text button with the provided click listener
+     */
+    public Builder withButton(@StringRes int buttonTextResourceId,
+        View.OnClickListener onClickListener) {
+      return withButton(view.getContext().getString(buttonTextResourceId), onClickListener);
+    }
+
+    /**
+     * Adds a button that opens the application settings when clicked
+     */
+    public Builder withOpenSettingsButton(String buttonText) {
+      this.buttonText = buttonText;
+      this.onClickListener = new SettingsClickListener();
+      return this;
+    }
+
+    /**
+     * Adds a button that opens the application settings when clicked
+     */
+    public Builder withOpenSettingsButton(@StringRes int buttonTextResourceId) {
+      return withOpenSettingsButton(view.getContext().getString(buttonTextResourceId));
+    }
+
+    /**
+     * Adds a callback to handle the snackbar {@code onDismissed} and {@code onShown} events.
+     */
+    public Builder withCallback(Snackbar.Callback callback) {
+      this.snackbarCallback = callback;
+      return this;
+    }
+
+    public Builder withDuration(int duration) {
+      this.duration = duration;
+      return this;
+    }
+
+    /**
+     * Builds a new instance of {@link SnackbarOnAnyPermanentlyDeniedMultiplePermissionsListener}
+     */
+    public SnackbarOnAnyPermanentlyDeniedMultiplePermissionsListener build() {
+      return new SnackbarOnAnyPermanentlyDeniedMultiplePermissionsListener(view, text, buttonText,
+          onClickListener, snackbarCallback, duration);
+    }
+  }
+}

--- a/dexter/src/main/java/com/karumi/dexter/listener/single/SnackbarOnDeniedPermissionListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/single/SnackbarOnDeniedPermissionListener.java
@@ -16,14 +16,13 @@
 
 package com.karumi.dexter.listener.single;
 
-import android.content.Context;
-import android.content.Intent;
-import android.net.Uri;
-import android.provider.Settings;
-import androidx.annotation.StringRes;
-import com.google.android.material.snackbar.Snackbar;
 import android.view.View;
+
+import com.google.android.material.snackbar.Snackbar;
 import com.karumi.dexter.listener.PermissionDeniedResponse;
+import com.karumi.dexter.listener.SettingsClickListener;
+
+import androidx.annotation.StringRes;
 
 /**
  * Utility listener that shows a {@link Snackbar} with a custom text whenever a permission has been
@@ -115,16 +114,7 @@ public class SnackbarOnDeniedPermissionListener extends BasePermissionListener {
      */
     public Builder withOpenSettingsButton(String buttonText) {
       this.buttonText = buttonText;
-      this.onClickListener = new View.OnClickListener() {
-        @Override public void onClick(View v) {
-          Context context = view.getContext();
-          Intent myAppSettings = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
-              Uri.parse("package:" + context.getPackageName()));
-          myAppSettings.addCategory(Intent.CATEGORY_DEFAULT);
-          myAppSettings.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-          context.startActivity(myAppSettings);
-        }
-      };
+      this.onClickListener = new SettingsClickListener();
       return this;
     }
 

--- a/dexter/src/main/java/com/karumi/dexter/listener/single/SnackbarOnDeniedPermissionListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/single/SnackbarOnDeniedPermissionListener.java
@@ -21,6 +21,7 @@ import android.view.View;
 import com.google.android.material.snackbar.Snackbar;
 import com.karumi.dexter.listener.PermissionDeniedResponse;
 import com.karumi.dexter.listener.SettingsClickListener;
+import com.karumi.dexter.listener.SnackbarUtils;
 
 import androidx.annotation.StringRes;
 
@@ -56,15 +57,7 @@ public class SnackbarOnDeniedPermissionListener extends BasePermissionListener {
 
   @Override public void onPermissionDenied(PermissionDeniedResponse response) {
     super.onPermissionDenied(response);
-
-    Snackbar snackbar = Snackbar.make(view, text, duration);
-    if (buttonText != null && onButtonClickListener != null) {
-      snackbar.setAction(buttonText, onButtonClickListener);
-    }
-    if (snackbarCallback != null) {
-      snackbar.addCallback(snackbarCallback);
-    }
-    snackbar.show();
+    SnackbarUtils.show(view, text, duration, buttonText, onButtonClickListener, snackbarCallback);
   }
 
   /**

--- a/dexter/src/main/java/com/karumi/dexter/listener/single/SnackbarOnPermanentlyDeniedPermissionListener.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/single/SnackbarOnPermanentlyDeniedPermissionListener.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2015 Karumi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.karumi.dexter.listener.single;
+
+import android.view.View;
+
+import com.google.android.material.snackbar.Snackbar;
+import com.karumi.dexter.listener.PermissionDeniedResponse;
+import com.karumi.dexter.listener.SettingsClickListener;
+import com.karumi.dexter.listener.SnackbarUtils;
+
+import androidx.annotation.StringRes;
+
+/**
+ * Utility listener that shows a {@link Snackbar} with a custom text whenever a permission has been
+ * permanently denied
+ */
+public class SnackbarOnPermanentlyDeniedPermissionListener extends BasePermissionListener {
+
+  private final View view;
+  private final String text;
+  private final String buttonText;
+  private final View.OnClickListener onButtonClickListener;
+  private final Snackbar.Callback snackbarCallback;
+  private final int duration;
+
+  /**
+   * @param view The view to find a parent from
+   * @param text Message displayed in the snackbar
+   * @param buttonText Message displayed in the snackbar button
+   * @param onButtonClickListener Action performed when the user clicks the snackbar button
+   */
+  private SnackbarOnPermanentlyDeniedPermissionListener(View view, String text, String buttonText,
+      View.OnClickListener onButtonClickListener, Snackbar.Callback snackbarCallback,
+      int duration) {
+    this.view = view;
+    this.text = text;
+    this.buttonText = buttonText;
+    this.onButtonClickListener = onButtonClickListener;
+    this.snackbarCallback = snackbarCallback;
+    this.duration = duration;
+  }
+
+  @Override public void onPermissionDenied(PermissionDeniedResponse response) {
+    super.onPermissionDenied(response);
+    if (response.isPermanentlyDenied()) {
+      SnackbarUtils.show(view, text, duration, buttonText, onButtonClickListener, snackbarCallback);
+    }
+  }
+
+  /**
+   * Builder class to configure the displayed snackbar
+   * Non set fields will not be shown
+   */
+  public static class Builder {
+    private final View view;
+    private final String text;
+    private String buttonText;
+    private View.OnClickListener onClickListener;
+    private Snackbar.Callback snackbarCallback;
+    private int duration = Snackbar.LENGTH_LONG;
+
+    private Builder(View view, String text) {
+      this.view = view;
+      this.text = text;
+    }
+
+    public static Builder with(View view, String text) {
+      return new Builder(view, text);
+    }
+
+    public static Builder with(View view, @StringRes int textResourceId) {
+      return Builder.with(view, view.getContext().getString(textResourceId));
+    }
+
+    /**
+     * Adds a text button with the provided click listener
+     */
+    public Builder withButton(String buttonText, View.OnClickListener onClickListener) {
+      this.buttonText = buttonText;
+      this.onClickListener = onClickListener;
+      return this;
+    }
+
+    /**
+     * Adds a text button with the provided click listener
+     */
+    public Builder withButton(@StringRes int buttonTextResourceId,
+        View.OnClickListener onClickListener) {
+      return withButton(view.getContext().getString(buttonTextResourceId), onClickListener);
+    }
+
+    /**
+     * Adds a button that opens the application settings when clicked
+     */
+    public Builder withOpenSettingsButton(String buttonText) {
+      this.buttonText = buttonText;
+      this.onClickListener = new SettingsClickListener();
+      return this;
+    }
+
+    /**
+     * Adds a button that opens the application settings when clicked
+     */
+    public Builder withOpenSettingsButton(@StringRes int buttonTextResourceId) {
+      return withOpenSettingsButton(view.getContext().getString(buttonTextResourceId));
+    }
+
+    /**
+     * Adds a callback to handle the snackbar {@code onDismissed} and {@code onShown} events
+     */
+    public Builder withCallback(Snackbar.Callback callback) {
+      this.snackbarCallback = callback;
+      return this;
+    }
+
+    /**
+     * Adds the duration of the snackbar on the screen
+     */
+    public Builder withDuration(int duration) {
+      this.duration = duration;
+      return this;
+    }
+
+    /**
+     * Builds a new instance of {@link SnackbarOnPermanentlyDeniedPermissionListener}
+     */
+    public SnackbarOnPermanentlyDeniedPermissionListener build() {
+      return new SnackbarOnPermanentlyDeniedPermissionListener(view, text, buttonText, onClickListener,
+          snackbarCallback, duration);
+    }
+  }
+}


### PR DESCRIPTION
### :tophat: What is the goal?
Provide an implementation of PermissionListener that show a Snackbar only when any permission has been permanently denied

### :memo: How is it being implemented?
-. Extract common behavior of the "Snackbar listener" implementation
-. Create `SnackbarOnAnyPermanentlyDeniedMultiplePermissionsListener` that shows a Snackbar whenever a permission of the requested list of permissions has been permanently denied
-. Create `SnackbarOnPermanentlyDeniedPermissionListener` that shows a Snackbar whenever a permission has been permanently denied

### :robot: How can it be tested?

- [ ] **Use case 1:** Ask for a single permission and configure a `SnackbarOnPermanentlyDeniedPermissionListener` as listener. When the permission is permanently denied, the snackbar should be shown
- [ ] **Use case 2:** Ask for a list of permission and configure a `SnackbarOnAnyPermanentlyDeniedMultiplePermissionsListener` as listener. When any permission is permanently denied, the snackbar should be shown