### PR TITLE
fix #262

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/Dexter.java
+++ b/dexter/src/main/java/com/karumi/dexter/Dexter.java
@@ -150,14 +150,15 @@ public final class Dexter
 
   /**
    * Method called whenever the DexterActivity has been destroyed.
+   * @param oldActivity the DexterActivity that was destroyed
    */
-  static void onActivityDestroyed() {
+  static void onActivityDestroyed(DexterActivity oldActivity) {
     /* Check against null values because sometimes the DexterActivity can call these internal
        methods when the DexterInstance has been cleaned up.
        Refer to this commit message for a more detailed explanation of the issue.
      */
     if (instance != null) {
-      instance.onActivityDestroyed();
+      instance.onActivityDestroyed(oldActivity);
     }
   }
 

--- a/dexter/src/main/java/com/karumi/dexter/DexterActivity.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterActivity.java
@@ -40,7 +40,7 @@ public final class DexterActivity extends Activity
 
   @Override protected void onDestroy() {
     super.onDestroy();
-    Dexter.onActivityDestroyed();
+    Dexter.onActivityDestroyed(this);
   }
 
   @Override protected void onNewIntent(Intent intent) {

--- a/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
+++ b/dexter/src/main/java/com/karumi/dexter/DexterInstance.java
@@ -121,9 +121,10 @@ final class DexterInstance {
 
   /**
    * Method called whenever the inner activity has been destroyed.
+   * @param oldActivity the DexterActivity that was destroyed
    */
-  void onActivityDestroyed() {
-    if (activity != null) {
+  void onActivityDestroyed(Activity oldActivity) {
+    if (activity == oldActivity) {
       activity = null;
       isRequestingPermission.set(false);
       rationaleAccepted.set(false);
@@ -318,7 +319,7 @@ final class DexterInstance {
     }
 
     if (activity != null && activity.isFinishing()) {
-      onActivityDestroyed();
+      onActivityDestroyed(activity);
     }
 
     pendingPermissions.clear();

--- a/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
+++ b/dexter/src/test/java/com/karumi/dexter/DexterInstanceTest.java
@@ -153,7 +153,7 @@ import static org.mockito.Mockito.when;
     givenPermissionIsAlreadyDenied(ANY_PERMISSION);
 
     whenCheckPermission(permissionListener, ANY_PERMISSION);
-    dexter.onActivityDestroyed();
+    dexter.onActivityDestroyed(activity);
     whenCheckPermission(permissionListener, ANY_PERMISSION);
 
     verifyRequestPermissions(new String[]{ANY_PERMISSION}, 2);


### PR DESCRIPTION
### :pushpin: References
* **Issue:** #262 

### :tophat: What is the goal?

Fix permission listener not called after starting new dialog

### :memo: How is it being implemented?

see https://github.com/Karumi/Dexter/issues/262#issuecomment-653900308

### :robot: How can it be tested?

- [ ] **Use case 1:** Start new Dialog from within the permission listener
- [ ] **Use case 2:** Start new Dialog when Animations triggered by previous permission listener are still going on (and thus the main thread is busy)
