### PR TITLE
Fix duplicated permission report

### DIFF
--- a/dexter/src/main/java/com/karumi/dexter/MultiplePermissionsReport.java
+++ b/dexter/src/main/java/com/karumi/dexter/MultiplePermissionsReport.java
@@ -18,34 +18,37 @@ package com.karumi.dexter;
 
 import com.karumi.dexter.listener.PermissionDeniedResponse;
 import com.karumi.dexter.listener.PermissionGrantedResponse;
+
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * An in detail report of the request permission process
  */
 public final class MultiplePermissionsReport {
 
-  private final List<PermissionGrantedResponse> grantedPermissionResponses;
-  private final List<PermissionDeniedResponse> deniedPermissionResponses;
+  private final Set<PermissionGrantedResponse> grantedPermissionResponses;
+  private final Set<PermissionDeniedResponse> deniedPermissionResponses;
 
   MultiplePermissionsReport() {
-    grantedPermissionResponses = new LinkedList<>();
-    deniedPermissionResponses = new LinkedList<>();
+    grantedPermissionResponses = new LinkedHashSet<>();
+    deniedPermissionResponses = new LinkedHashSet<>();
   }
 
   /**
    * Returns a collection with all the permissions that has been granted
    */
   public List<PermissionGrantedResponse> getGrantedPermissionResponses() {
-    return grantedPermissionResponses;
+    return new LinkedList<>(grantedPermissionResponses);
   }
 
   /**
    * Returns a collection with all the permissions that has been denied
    */
   public List<PermissionDeniedResponse> getDeniedPermissionResponses() {
-    return deniedPermissionResponses;
+    return new LinkedList<>(deniedPermissionResponses);
   }
 
   /**

--- a/dexter/src/main/java/com/karumi/dexter/listener/PermissionDeniedResponse.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/PermissionDeniedResponse.java
@@ -53,4 +53,21 @@ public final class PermissionDeniedResponse {
   public boolean isPermanentlyDenied() {
     return permanentlyDenied;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PermissionDeniedResponse that = (PermissionDeniedResponse) o;
+    return requestedPermission.getName().equals(that.requestedPermission.getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return requestedPermission.getName().hashCode();
+  }
 }

--- a/dexter/src/main/java/com/karumi/dexter/listener/PermissionGrantedResponse.java
+++ b/dexter/src/main/java/com/karumi/dexter/listener/PermissionGrantedResponse.java
@@ -44,4 +44,21 @@ public final class PermissionGrantedResponse {
   public String getPermissionName() {
     return requestedPermission.getName();
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    PermissionGrantedResponse that = (PermissionGrantedResponse) o;
+    return requestedPermission.getName().equals(that.requestedPermission.getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return requestedPermission.getName().hashCode();
+  }
 }

--- a/dexter/src/test/java/com/karumi/dexter/MultiplePermissionsReportTest.java
+++ b/dexter/src/test/java/com/karumi/dexter/MultiplePermissionsReportTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2015 Karumi.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.karumi.dexter;
+
+import com.karumi.dexter.listener.PermissionDeniedResponse;
+import com.karumi.dexter.listener.PermissionGrantedResponse;
+
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static junit.framework.TestCase.assertEquals;
+
+public class MultiplePermissionsReportTest {
+
+    private static final PermissionGrantedResponse GRANTED_RESPONSE =
+            PermissionGrantedResponse.from("CAMERA");
+    private static final PermissionGrantedResponse OTHER_GRANTED_RESPONSE =
+            PermissionGrantedResponse.from("CONTACTS");
+    private static final PermissionDeniedResponse DENIED_RESPONSE =
+            PermissionDeniedResponse.from("MICROPHONE", true);
+    private static final PermissionDeniedResponse OTHER_DENIED_RESPONSE =
+            PermissionDeniedResponse.from("STORAGE", false);
+
+    @Test
+    public void shouldReplaceOldPermissionGrantedReportsWithTheNewOnes() {
+        MultiplePermissionsReport report = new MultiplePermissionsReport();
+
+        report.addGrantedPermissionResponse(GRANTED_RESPONSE);
+        report.addGrantedPermissionResponse(OTHER_GRANTED_RESPONSE);
+        report.addGrantedPermissionResponse(GRANTED_RESPONSE);
+
+        List<PermissionGrantedResponse> expectedPermissions = new LinkedList<>();
+        expectedPermissions.add(GRANTED_RESPONSE);
+        expectedPermissions.add(OTHER_GRANTED_RESPONSE);
+        assertEquals(expectedPermissions, report.getGrantedPermissionResponses());
+    }
+
+    @Test
+    public void shouldReplaceOldPermissionDeniedReportsWithTheNewOnes() {
+        MultiplePermissionsReport report = new MultiplePermissionsReport();
+
+        report.addDeniedPermissionResponse(DENIED_RESPONSE);
+        report.addDeniedPermissionResponse(OTHER_DENIED_RESPONSE);
+        report.addDeniedPermissionResponse(DENIED_RESPONSE);
+
+        List<PermissionDeniedResponse> expectedPermissions = new LinkedList<>();
+        expectedPermissions.add(DENIED_RESPONSE);
+        expectedPermissions.add(OTHER_DENIED_RESPONSE);
+        assertEquals(expectedPermissions, report.getDeniedPermissionResponses());
+    }
+}


### PR DESCRIPTION
### :pushpin: References
* **Issue:** Fixes #270 

### :tophat: What is the goal?

Fix an error related to the permission reports being duplicated under some circumstances.

### :memo: How is it being implemented?

We've just updated ``MultiplePermissionsReport`` to use a ``Set`` instead of a ``List`` so we do not duplicate the reported permissions when handling the same set of permissions consecutively. Last but not least, we've added coverage.

### :robot: How can it be tested?

🤖 